### PR TITLE
support pinning go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ call the desired specific version of the executed command.
 
 In order to decide which version to use, wrapper commands will follow these
 rules:
-1. If current directory is a Go module project:
-   1. If no compatible version installed, it will suggest the user to install
-      latest compatible version and use it
-   1. If compatible versions are installed, it will use latest compatible version
-1. If not in go modules project:
+1. If current directory is part of a Go project:
+   1. If `.go-version` exists in project root, it will select the version
+      defined in that file as candidate. Otherwise, it will select the version
+      defined in `go.mod`
+   1. If no matching version installed for selected version, it will suggest
+      the user to install latest compatible version and use it
+   1. If compatible versions are installed for selected version, it will use
+      latest compatible version
+1. If not in go project:
    1. If default version configured, it will use that version
-   1. If no versions installed, it will suggest to install latest Go version and
-      it will use it
+   1. If no versions installed, it will suggest to install latest Go version
+      and it will use it
    1. Otherwise, it will use latest installed Go version

--- a/cmd/gowrap/commands/project.go
+++ b/cmd/gowrap/commands/project.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"os"
+	"strings"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/xabierlaiseca/gowrap/pkg/project"
+	"github.com/xabierlaiseca/gowrap/pkg/semver"
+	"github.com/xabierlaiseca/gowrap/pkg/util/customerrors"
+)
+
+func NewProjectCommand(app *kingpin.Application) {
+	cmd := app.Command("project", "Project operations")
+	newProjectPinCommand(cmd)
+}
+
+func newProjectPinCommand(parent *kingpin.CmdClause) {
+	cmd := parent.Command("pin", "Pin specific version for current project")
+	version := cmd.Arg("version", "version to pin").
+		Required().
+		HintAction(availableVersionCompletion).
+		String()
+
+	cmd.
+		Validate(func(*kingpin.CmdClause) error {
+			if len(*version) == 0 || (semver.IsValid(*version) && strings.Count(*version, ".") == 2) {
+				return nil
+			}
+			return customerrors.Errorf("invalid version provided: %s, 'a.b.c' like version required", *version)
+		}).
+		Action(func(*kingpin.ParseContext) error {
+			wd, err := os.Getwd()
+			if err != nil {
+				return err
+			}
+
+			return project.PinVersion(wd, *version)
+		})
+}

--- a/cmd/gowrap/main.go
+++ b/cmd/gowrap/main.go
@@ -9,11 +9,12 @@ import (
 
 func main() {
 	app := kingpin.New("gowrap", "Utility to manage installed go versions")
-	commands.NewVersionsFileCommand(app)
-	commands.NewListCommand(app)
-	commands.NewInstallCommand(app)
-	commands.NewUninstallCommand(app)
 	commands.NewConfigureCommand(app)
+	commands.NewInstallCommand(app)
+	commands.NewListCommand(app)
+	commands.NewProjectCommand(app)
+	commands.NewUninstallCommand(app)
+	commands.NewVersionsFileCommand(app)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/pkg/project/common.go
+++ b/pkg/project/common.go
@@ -1,0 +1,94 @@
+package project
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/xabierlaiseca/gowrap/pkg/util/customerrors"
+	"golang.org/x/mod/modfile"
+)
+
+const (
+	goModFile     = "go.mod"
+	goVersionFile = ".go-version"
+)
+
+func findProjectRoot(directory string) (string, error) {
+	candidateGoModPath := filepath.Join(directory, goModFile)
+	if goModExists, err := fileExists(candidateGoModPath); err != nil {
+		return "", err
+	} else if goModExists {
+		return directory, nil
+	}
+
+	candidateGoVersionPath := filepath.Join(directory, goVersionFile)
+	if goVersionExists, err := fileExists(candidateGoVersionPath); err != nil {
+		return "", err
+	} else if goVersionExists {
+		return directory, nil
+	}
+
+	parent := filepath.Dir(directory)
+	if parent == directory {
+		return "", customerrors.NotFound()
+	}
+
+	return findProjectRoot(parent)
+}
+
+func fileExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+
+	return err == nil && !info.Mode().IsDir(), nil
+}
+
+func findGoVersion(projectRoot string) (string, error) {
+	version, err := findVersionInGoVersionFile(projectRoot)
+	if err == nil {
+		return version, nil
+	} else if customerrors.IsNotFound(err) {
+		return findVersionInGoModFile(projectRoot)
+	}
+
+	return "", err
+}
+
+func findVersionInGoVersionFile(projectRoot string) (string, error) {
+	goVersionPath := filepath.Join(projectRoot, goVersionFile)
+	content, err := readFile(goVersionPath)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(content)), nil
+}
+
+func findVersionInGoModFile(projectRoot string) (string, error) {
+	goModPath := filepath.Join(projectRoot, goModFile)
+	content, err := readFile(goModPath)
+	if err != nil {
+		return "", err
+	}
+
+	goMod, err := modfile.ParseLax(goModPath, content, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return goMod.Go.Version, nil
+}
+
+func readFile(path string) ([]byte, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil, customerrors.NotFound()
+	} else if err != nil {
+		return nil, err
+	}
+
+	return ioutil.ReadFile(path)
+}

--- a/pkg/project/detectversion.go
+++ b/pkg/project/detectversion.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,11 +8,6 @@ import (
 	"github.com/xabierlaiseca/gowrap/pkg/config"
 	"github.com/xabierlaiseca/gowrap/pkg/util/customerrors"
 	"github.com/xabierlaiseca/gowrap/pkg/versions"
-	"golang.org/x/mod/modfile"
-)
-
-const (
-	goModFile = "go.mod"
 )
 
 func DetectVersion(path string) (string, error) {
@@ -44,38 +38,4 @@ func DetectVersion(path string) (string, error) {
 	}
 
 	return findGoVersion(projectRoot)
-}
-
-func findProjectRoot(directory string) (string, error) {
-	candidateGoModPath := filepath.Join(directory, goModFile)
-	info, err := os.Stat(candidateGoModPath)
-	if err != nil && !os.IsNotExist(err) {
-		return "", err
-	}
-
-	if err == nil && !info.Mode().IsDir() {
-		return directory, nil
-	}
-
-	parent := filepath.Dir(directory)
-	if parent == directory {
-		return "", customerrors.NotFound()
-	}
-
-	return findProjectRoot(parent)
-}
-
-func findGoVersion(projectRoot string) (string, error) {
-	goModPath := filepath.Join(projectRoot, "go.mod")
-	content, err := ioutil.ReadFile(goModPath)
-	if err != nil {
-		return "", err
-	}
-
-	goMod, err := modfile.ParseLax(goModPath, content, nil)
-	if err != nil {
-		return "", err
-	}
-
-	return goMod.Go.Version, nil
 }

--- a/pkg/project/version.go
+++ b/pkg/project/version.go
@@ -1,0 +1,33 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"github.com/xabierlaiseca/gowrap/pkg/semver"
+	"github.com/xabierlaiseca/gowrap/pkg/util/customerrors"
+)
+
+func PinVersion(path string, version string) error {
+	projectRoot, err := findProjectRoot(path)
+	if err != nil {
+		return err
+	}
+
+	if goModVersion, err := findVersionInGoModFile(projectRoot); err != nil && !customerrors.IsNotFound(err) {
+		return err
+	} else if err == nil && !semver.HasPrefix(version, goModVersion) {
+		logrus.Warningf("Pinned version (%s) is not compatible with version in go.mod (%s)", version, goModVersion)
+	}
+
+	goVersionPath := filepath.Join(projectRoot, goVersionFile)
+	file, err := os.OpenFile(goVersionPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = file.Write([]byte(version))
+	return err
+}


### PR DESCRIPTION
Allow pinning go version for a given project using `.go-version` file.

The value in `.go-version` file will have preference over version in `go.mod` file.