### PR TITLE
fail git diff-index if changes [skip changelog]

### DIFF
--- a/.github/workflows/generate-versions-file.yml
+++ b/.github/workflows/generate-versions-file.yml
@@ -24,7 +24,7 @@ jobs:
 
       - id: check-versions-file
         name: Check if changes in versions file
-        run: git diff-index HEAD data/versions.json
+        run: git diff-index --exit-code HEAD data/versions.json
         continue-on-error: true
 
       - name: Commit files


### PR DESCRIPTION
Last night, when the generate versions file was build, the new file wasn't published because the exit code of `git diff-index` was 0 enven if they were changes. Adding `--exit-code` will fix that.