### PR TITLE
allow skipping build based on commit message

### DIFF
--- a/.github/workflows/generate-versions-file.yml
+++ b/.github/workflows/generate-versions-file.yml
@@ -32,7 +32,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "Generate Versions File Action"
           git add data/versions.json
-          git commit -m "new versions file $(date +%F)"
+          git commit -m "new versions file $(date +%F) [skip ci]"
         if: "steps.check-versions-file.outcome == 'failure'"
 
       - name: Push changes

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
       - name: set up Go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -58,6 +58,7 @@ changelog:
     - '^docs:'
     - '^test:'
     - '\[skip changelog\]'
+    - '\[skip ci\]'
 
 release:
   github:


### PR DESCRIPTION
Apart from not triggering the build, it won't be added to release changelog. Version file generation commits are tagged with `[skip ci]`.