### PR TITLE
replaced automatic upgrades functionallity with automatic installs

### DIFF
--- a/cmd/common/updates.go
+++ b/cmd/common/updates.go
@@ -51,7 +51,7 @@ func trySelfUpgrade(gowrapHome, currentVersion string) error {
 	}
 
 	c, err := config.Load(gowrapHome)
-	if err != nil || c.SelfUpgrades == config.SelfUpgradesDisabled {
+	if err != nil || c.SelfUpgrade == config.SelfUpgradesDisabled {
 		return nil
 	}
 

--- a/cmd/generic-cmd-wrapper/cli/cli.go
+++ b/cmd/generic-cmd-wrapper/cli/cli.go
@@ -1,14 +1,9 @@
 package cli
 
 import (
-	"bufio"
-	"fmt"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/xabierlaiseca/gowrap/pkg/config"
-
 	"github.com/xabierlaiseca/gowrap/pkg/project"
 	"github.com/xabierlaiseca/gowrap/pkg/semver"
 	"github.com/xabierlaiseca/gowrap/pkg/util/customerrors"
@@ -44,38 +39,31 @@ type SubCommand struct {
 
 func findVersionToUse(gowrapHome, wd string) (string, error) {
 	detectedVersion, err := project.DetectVersion(gowrapHome, wd)
+	if err != nil && !customerrors.IsNotFound(err) {
+		return "", err
+	}
+
+	installedVersion, err := autoInstallVersionIfConfigured(gowrapHome, detectedVersion)
 	if err != nil {
 		return "", err
+	}
+
+	if len(installedVersion) > 0 {
+		return installedVersion, nil
 	} else if detectedVersion.IsAvailable() {
-		return upgradeVersionIfConfigured(gowrapHome, detectedVersion)
+		return detectedVersion.Installed, nil
 	}
-
-	candidate, err := versions.FindLatestAvailable(detectedVersion.Defined)
-	if err != nil {
-		return "", err
-	}
-
-	if accepted, err := installIfAccepted(gowrapHome, candidate, "No suitable version installed found"); err != nil {
-		return "", err
-	} else if !accepted {
-		return candidate, nil
-	}
-
 	return "", customerrors.Errorf("no versions available for go %s installed", detectedVersion.Defined)
 }
 
-func upgradeVersionIfConfigured(gowrapHome string, version *project.Version) (string, error) {
-	if semver.IsFullVersion(version.Defined) {
-		return version.Installed, nil
-	}
-
+func autoInstallVersionIfConfigured(gowrapHome string, version *project.Version) (string, error) {
 	c, err := config.Load(gowrapHome)
 	if err != nil {
 		return "", err
 	}
 
-	if c.Upgrades == config.UpgradesDisabled {
-		return version.Installed, nil
+	if c.AutoInstall == config.AutoInstallDisabled || (c.AutoInstall == config.AutoInstallMissing && version.IsAvailable()) {
+		return "", nil
 	}
 
 	candidate, err := versions.FindLatestAvailable(version.Defined)
@@ -84,59 +72,9 @@ func upgradeVersionIfConfigured(gowrapHome string, version *project.Version) (st
 	}
 
 	if !semver.IsLessThan(version.Installed, candidate) {
-		return version.Installed, nil
+		return "", nil
 	}
 
-	if c.Upgrades == config.UpgradesAuto {
-		_, err := versions.InstallIfNotInstalled(gowrapHome, candidate)
-		return candidate, err
-	}
-
-	accepted, err := installIfAccepted(gowrapHome, candidate, fmt.Sprintf("Upgrade found for version %s", version.Defined))
-	if err != nil {
-		return "", err
-	} else if accepted {
-		return candidate, nil
-	}
-
-	return version.Installed, nil
-}
-
-func installIfAccepted(gowrapHome, candidate, messagePrefix string) (bool, error) {
-	reader := bufio.NewReader(os.Stdin)
-	accepted, err := askForInstallingVersion(reader, candidate, messagePrefix)
-	if err != nil {
-		return false, err
-	}
-
-	if accepted {
-		_, err := versions.InstallIfNotInstalled(gowrapHome, candidate)
-		return true, err
-	}
-
-	return false, nil
-}
-
-func askForInstallingVersion(reader *bufio.Reader, candidate, messagePrefix string) (bool, error) {
-	fmt.Printf("%s, would you like to install %s? (Y/n): ", messagePrefix, candidate)
-	text, err := reader.ReadString('\n')
-	if err != nil {
-		return false, err
-	}
-
-	text = strings.ToLower(strings.TrimSpace(text))
-
-	if len(text) == 0 {
-		text = "y"
-	}
-
-	switch {
-	case strings.HasPrefix(text, "y"):
-		return true, nil
-	case strings.HasPrefix(text, "n"):
-		return false, nil
-	default:
-		fmt.Printf("Unexpected option provided: %s\n", text)
-		return askForInstallingVersion(reader, candidate, messagePrefix)
-	}
+	_, err = versions.InstallIfNotInstalled(gowrapHome, candidate)
+	return candidate, err
 }

--- a/cmd/gowrap/commands/run.go
+++ b/cmd/gowrap/commands/run.go
@@ -30,7 +30,7 @@ func RunCli(gowrapVersion, gowrapHome, wd string, args []string) error {
 
 func selfUpgradeAction(currentVersion, gowrapHome string) func(context *kingpin.ParseContext) error {
 	return func(context *kingpin.ParseContext) error {
-		if context.String() == "configure selfupgrades" {
+		if context.String() == "configure selfupgrade" {
 			return nil
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,9 +12,9 @@ const (
 )
 
 const (
-	UpgradesAuto     string = "auto"
-	UpgradesAsk      string = "ask"
-	UpgradesDisabled string = "disabled"
+	AutoInstallEnabled  string = "enabled"
+	AutoInstallMissing  string = "missing"
+	AutoInstallDisabled string = "disabled"
 
 	SelfUpgradesEnabled  = "enabled"
 	SelfUpgradesDisabled = "disabled"
@@ -23,15 +23,15 @@ const (
 type Configuration struct {
 	gowrapHome     string
 	DefaultVersion string `json:"defaultVersion,omitempty"`
-	Upgrades       string `json:"upgrades,omitempty"`
-	SelfUpgrades   string `json:"selfUpgrades,omitempty"`
+	AutoInstall    string `json:"autoInstall,omitempty"`
+	SelfUpgrade    string `json:"selfUpgrade,omitempty"`
 }
 
 func Load(gowrapHome string) (*Configuration, error) {
 	cfg := &Configuration{
-		gowrapHome:   gowrapHome,
-		Upgrades:     UpgradesDisabled,
-		SelfUpgrades: SelfUpgradesDisabled,
+		gowrapHome:  gowrapHome,
+		AutoInstall: AutoInstallMissing,
+		SelfUpgrade: SelfUpgradesDisabled,
 	}
 	configFilePath := getConfigFilePath(gowrapHome)
 	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {

--- a/pkg/project/detectversion.go
+++ b/pkg/project/detectversion.go
@@ -50,7 +50,7 @@ func DetectVersion(gowrapHome, path string) (*Version, error) {
 	}
 
 	installedVersion, err := versions.FindLatestInstalledForPrefix(gowrapHome, definedVersion)
-	if err != nil {
+	if err != nil && !customerrors.IsNotFound(err) {
 		return nil, err
 	}
 


### PR DESCRIPTION
Automatic installs is a bit broader concept as it also cover when no version is available. Support for requesting user's input before installing a version has been removed.