### PR TITLE
fix remote file link generation

### DIFF
--- a/data/versions.json
+++ b/data/versions.json
@@ -1,77 +1,77 @@
 {
   "1.10": [
     {
-      "url": "/dl/go1.10.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.darwin-amd64.tar.gz",
       "checksum": "511a4799e8d64cda3352bb7fe72e359689ea6ef0455329cda6b6e1f3137326c1",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.freebsd-386.tar.gz",
       "checksum": "d1e84cc46fa7290a6849c794785d629239f07c6f3e565616fa5421dd51344211",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.freebsd-amd64.tar.gz",
       "checksum": "9ecc9dd288e9727b9ed250d5adbcf21073c038391e8d96aff46c20800be317c3",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.linux-386.tar.gz",
       "checksum": "2d26a9f41fd80eeb445cc454c2ba6b3d0db2fc732c53d7d0427a9f605bfc55a1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.linux-amd64.tar.gz",
       "checksum": "b5a64335f1490277b585832d1f6c7f8c6c11206cba5cd3f771dcb87b98ad1a33",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.linux-arm64.tar.gz",
       "checksum": "efb47e5c0e020b180291379ab625c6ec1c2e9e9b289336bc7169e6aa1da43fd8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.linux-armv6l.tar.gz",
       "checksum": "6ff665a9ab61240cf9f11a07e03e6819e452a618a32ea05bbb2c80182f838f4f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.linux-ppc64le.tar.gz",
       "checksum": "a1e22e2fbcb3e551e0bf59d0f8aeb4b3f2df86714f09d2acd260c6597c43beee",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.linux-s390x.tar.gz",
       "checksum": "71cde197e50afe17f097f81153edb450f880267699f22453272d184e0f4681d7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.windows-386.zip",
       "checksum": "83edd9e52ce6d1c8f911e7bbf6f0a73952c613b4bf66438ceb1507f892240f11",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.windows-amd64.zip",
       "checksum": "210b223031c254a6eb8fa138c3782b23af710a9959d64b551fa81edd762ea167",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -80,77 +80,77 @@
   ],
   "1.10.1": [
     {
-      "url": "/dl/go1.10.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.darwin-amd64.tar.gz",
       "checksum": "0a5bbcbbb0d150338ba346151d2864fd326873beaedf964e2057008c8a4dc557",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.freebsd-386.tar.gz",
       "checksum": "3e7f0967348d554ebe385f2372411ecfdbdc3074c8ff3ccb9f2910a765c4e472",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.freebsd-amd64.tar.gz",
       "checksum": "41f57f91363c81523ec23d4a25f0ba92bd66a8c1a35b6df82491a8413bd2cd62",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.linux-386.tar.gz",
       "checksum": "acbe19d56123549faf747b4f61b730008b185a0e2145d220527d2383627dfe69",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.linux-amd64.tar.gz",
       "checksum": "72d820dec546752e5a8303b33b009079c15c2390ce76d67cf514991646c6127b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.1.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.linux-arm64.tar.gz",
       "checksum": "1e07a159414b5090d31166d1a06ee501762076ef21140dcd54cdcbe4e68a9c9b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.linux-armv6l.tar.gz",
       "checksum": "feca4e920d5ca25001dc0823390df79bc7ea5b5b8c03483e5a2c54f164654936",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.1.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.linux-ppc64le.tar.gz",
       "checksum": "91d0026bbed601c4aad332473ed02f9a460b31437cbc6f2a37a88c0376fc3a65",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.1.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.1.linux-s390x.tar.gz",
       "checksum": "e211a5abdacf843e16ac33a309d554403beb63959f96f9db70051f303035434b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.1.windows-386.zip",
       "checksum": "2f09edd066cc929bb362262afab27609e8d4b96f7dfd3f3844238e3214db9b8a",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.1.windows-amd64.zip",
       "checksum": "17f7664131202b469f4264161ff3cd0796e8398249d2b646bbe4990301afc678",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -159,77 +159,77 @@
   ],
   "1.10.2": [
     {
-      "url": "/dl/go1.10.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.darwin-amd64.tar.gz",
       "checksum": "360ad908840217ee1b2a0b4654666b9abb3a12c8593405ba88ab9bba6e64eeda",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.freebsd-386.tar.gz",
       "checksum": "f272774839a95041cf8874171ef6a8c6692e8784544ca05abbb29c66643d24a9",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.freebsd-amd64.tar.gz",
       "checksum": "6174ff4c2da7ebb064e7f2b28419d2cd5d3f7de34bec9e42d3716bdb190c9955",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.linux-386.tar.gz",
       "checksum": "ea4caddf76b86ed5d101a61bc9a273be5b24d81f0567270bb4d5beaaded9b567",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.linux-amd64.tar.gz",
       "checksum": "4b677d698c65370afa33757b6954ade60347aaca310ea92a63ed717d7cb0c2ff",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.2.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.linux-arm64.tar.gz",
       "checksum": "d6af66c71b12d63c754d5bf49c3007dc1c9821eb1a945118bfd5a539a327c4c8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.2.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.linux-armv6l.tar.gz",
       "checksum": "529a16b531d4561572db6ba9d357215b58a1953437a63e76dc0c597be9e25dd2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.2.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.linux-ppc64le.tar.gz",
       "checksum": "f0748502c90e9784b6368937f1d157913d18acdae72ac75add50e5c0c9efc85c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.2.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.2.linux-s390x.tar.gz",
       "checksum": "2266b7ebdbca13c21a1f6039c9f6887cd2c01617d1e2716ff4595307a0da1d46",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.2.windows-386.zip",
       "checksum": "0bb12875044674d632d1f1b2f53cf33510a6df914178fe672f3f70f6f6cdf80d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.2.windows-amd64.zip",
       "checksum": "0fb4a893796e8151c0b8d0a3da4ed8cbb22bf6d98a3c29c915be4d7083f146ee",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -238,77 +238,77 @@
   ],
   "1.10.3": [
     {
-      "url": "/dl/go1.10.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.darwin-amd64.tar.gz",
       "checksum": "131fd430350a3134d352ee75c5ca456cdf4443e492d0527a9651c7c04e2b458d",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.freebsd-386.tar.gz",
       "checksum": "92a28ccd8caa173295490dfd3f1d10f3bc7eaf0953bf099631bc6c57a5842704",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.freebsd-amd64.tar.gz",
       "checksum": "231d9e6f3b5acee1193cd18b98c89f1a51570fbc8ba7c6c6b67a7f7ff2985e2b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.linux-386.tar.gz",
       "checksum": "3d5fe1932c904a01acb13dae07a5835bffafef38bef9e5a05450c52948ebdeb4",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.linux-amd64.tar.gz",
       "checksum": "fa1b0e45d3b647c252f51f5e1204aba049cde4af177ef9f2181f43004f901035",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.3.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.linux-arm64.tar.gz",
       "checksum": "355128a05b456c9e68792143801ad18e0431510a53857f640f7b30ba92624ed2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.linux-armv6l.tar.gz",
       "checksum": "d3df3fa3d153e81041af24f31a82f86a21cb7b92c1b5552fb621bad0320f06b6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.3.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.linux-ppc64le.tar.gz",
       "checksum": "f3640b2f0990a9617c937775f669ee18f10a82e424e5f87a8ce794a6407b8347",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.3.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.3.linux-s390x.tar.gz",
       "checksum": "34385f64651f82fbc11dc43bdc410c2abda237bdef87f3a430d35a508ec3ce0d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.3.windows-386.zip",
       "checksum": "89696a29bdf808fa9861216a21824ae8eb2e750a54b1424ce7f2a177e5cd1466",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.3.windows-amd64.zip",
       "checksum": "a3f19d4fc0f4b45836b349503e347e64e31ab830dedac2fc9c390836d4418edb",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -317,77 +317,77 @@
   ],
   "1.10.4": [
     {
-      "url": "/dl/go1.10.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.darwin-amd64.tar.gz",
       "checksum": "2ba324f01de2b2ece0376f6d696570a4c5c13db67d00aadfd612adc56feff587",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.freebsd-386.tar.gz",
       "checksum": "d2d375daf6352e7b2d4f0dc8a90d1dbc463b955221b9d87fb1fbde805c979bb2",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.freebsd-amd64.tar.gz",
       "checksum": "ad2fbf6ab2d1754f4ae5d8f6488bdcc6cc48dd15cac29207f38f7cbf0978ed17",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.linux-386.tar.gz",
       "checksum": "771f48e55776d4abc9c2a74907457066c7c282ac05fa01cf5ff4422ced76d2ee",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.linux-amd64.tar.gz",
       "checksum": "fa04efdb17a275a0c6e137f969a1c4eb878939e91e1da16060ce42f02c2ec5ec",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.4.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.linux-arm64.tar.gz",
       "checksum": "2e0f9e99aeefaabba280b2bf85db0336da122accde73603159b3d72d0b2bd512",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.linux-armv6l.tar.gz",
       "checksum": "4e1e80bd98f3598c0c48ba0c189c836d01b602bfc769b827a4bfed01d2c14b21",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.linux-ppc64le.tar.gz",
       "checksum": "1cfc147357c0be91a988998046997c5f30b20c6baaeb6cd5774717714db76093",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.4.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.4.linux-s390x.tar.gz",
       "checksum": "5593d770d6544090c1bb20d57bb34c743131470695e195fbe5352bf056927a35",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.4.windows-386.zip",
       "checksum": "407e5619048c427de4a65b26edb17d54c220f8c30ebd358961b1785a38394ec9",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.4.windows-amd64.zip",
       "checksum": "5499aa98399664df8dc1da5c3aaaed14b3130b79c713b5677a0ee9e93854476c",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -396,77 +396,77 @@
   ],
   "1.10.5": [
     {
-      "url": "/dl/go1.10.5.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.darwin-amd64.tar.gz",
       "checksum": "36873d9935f7f3519da11c9e928b66c94ccbf71c37df71b7635e804a226ae631",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.5.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.freebsd-386.tar.gz",
       "checksum": "6533503d07f1f966966d5342584eca036aea72339af6da3b2db74bee94df8ac1",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.5.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.freebsd-amd64.tar.gz",
       "checksum": "a742a8a2feec059ee32d79c9d72a11c87857619eb6d4fa7910c62a49901142c4",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.5.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.linux-386.tar.gz",
       "checksum": "bc1bd42405a551ba7ac86b79b9d23a5635f21de53caf684acd8bf5dfee8bef5d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.5.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.linux-amd64.tar.gz",
       "checksum": "a035d9beda8341b645d3f45a1b620cf2d8fb0c5eb409be36b389c0fd384ecc3a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.5.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.linux-arm64.tar.gz",
       "checksum": "b4c16fcee18bc79de2fa4776c8d0f9bc164ddfc32101e96fe1da83ebe881e3df",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.5.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.linux-armv6l.tar.gz",
       "checksum": "1d864a6d0ec599de9112c8354dcaaa886b4df928757966939402598e9bd9c238",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.5.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.linux-ppc64le.tar.gz",
       "checksum": "8fc13736d383312710249b24adf05af59ff14dacb73d9bd715ff463bc89c5c5f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.5.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.5.linux-s390x.tar.gz",
       "checksum": "e90269495fab7ef99aea6937caf7a049896b2dc7b181456f80a506e69a8b57fc",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.5.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.5.windows-386.zip",
       "checksum": "e936532cc0d3ea9470129ba6df3714924fbc709a9441209a8154503cf16823f2",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.5.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.5.windows-amd64.zip",
       "checksum": "d88a32eb4d1fc3b11253c9daa2ef397c8700f3ba493b41324b152e6cda44d2b4",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -475,77 +475,77 @@
   ],
   "1.10.6": [
     {
-      "url": "/dl/go1.10.6.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.darwin-amd64.tar.gz",
       "checksum": "419e7a775c39074ff967b4e66fa212eb4fd310b1f15675ce13977b57635dd3a8",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.6.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.freebsd-386.tar.gz",
       "checksum": "d1f0aef497588865967256030cb676c6c62f6a4b53649814e753ae150fbaa960",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.6.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.freebsd-amd64.tar.gz",
       "checksum": "194a1a39a96bb8d7ed8370dae7768db47109f628aea4f1588f677f66c384955a",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.6.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.linux-386.tar.gz",
       "checksum": "171fe6cbecb2845b875a35ac7ad758d4c0c5bd03f330fa35d340de85b9070e71",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.6.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.linux-amd64.tar.gz",
       "checksum": "acbdedf28b55b38d2db6f06209a25a869a36d31bdcf09fd2ec3d40e1279e0592",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.6.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.linux-arm64.tar.gz",
       "checksum": "0fcbfbcbf6373c0b6876786900a4a100c1ed9af86bd3258f23ab498cca4c02a1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.6.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.linux-armv6l.tar.gz",
       "checksum": "4da252fc7e834b7ce35d349fb581aa84a08adece926a0b9a8e4216451ffcb11e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.6.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.linux-ppc64le.tar.gz",
       "checksum": "ebd7e4688f3e1baabbc735453b19c6c27116e1f292bf46622123bfc4c160c747",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.6.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.6.linux-s390x.tar.gz",
       "checksum": "0223daa57bdef5bf85d308f6d2793c58055d294c13cbaca240ead2f568de2e9f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.6.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.6.windows-386.zip",
       "checksum": "2f3ded109a37d53bd8600fa23c07d9abea41fb30a5f5954bbc97e9c57d8e0ce0",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.6.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.6.windows-amd64.zip",
       "checksum": "fc57f16c23b7fb41b664f549ff2ed6cca340555e374c5ff52fa296cd3f228f32",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -554,77 +554,77 @@
   ],
   "1.10.7": [
     {
-      "url": "/dl/go1.10.7.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.darwin-amd64.tar.gz",
       "checksum": "700725a36d29d6e5d474a887acbf490c3d2762d719bdfef8370e22198077297d",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.7.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.freebsd-386.tar.gz",
       "checksum": "d45bd54c38169ba228a67a17c92560e5a455405f6f5116a030c512510b06987c",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.7.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.freebsd-amd64.tar.gz",
       "checksum": "21c9bda5fa37d668348e65b2374de6da84c85d601e45bbba4d8e2c86450f2a95",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.7.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.linux-386.tar.gz",
       "checksum": "55cd25e550cb8ce8250dbc9eda56b9c10b3097c7f6beed45066fbaaf8c6c1ebd",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.7.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.linux-amd64.tar.gz",
       "checksum": "1aabe10919048822f3bb1865f7a22f8b78387a12c03cd573101594bc8fb33579",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.7.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.linux-arm64.tar.gz",
       "checksum": "cb5a274f7c8f6186957e4503e724dda8aeffe84b76a146748c55ea5bb22d9ae4",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.7.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.linux-armv6l.tar.gz",
       "checksum": "1f81c995f829c8fc7def4d0cc1bde63cac1834386e6f650f2cd7be56ab5e8b98",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.7.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.linux-ppc64le.tar.gz",
       "checksum": "11279ffebfcfa875b0552839d428cc72e2056e68681286429b57173c0da91fb4",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.7.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.7.linux-s390x.tar.gz",
       "checksum": "e0d7802029ed8d2720a2b27ec1816e71cb29f818380abb8b449080e97547881e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.7.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.7.windows-386.zip",
       "checksum": "bbd297a456aded5dcafe91194aafec883802cd0982120c735d15a39810248ea7",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.7.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.7.windows-amd64.zip",
       "checksum": "791e2d5a409932157ac87f4da7fa22d5e5468b784d5933121e4a747d89639e15",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -633,77 +633,77 @@
   ],
   "1.10.8": [
     {
-      "url": "/dl/go1.10.8.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.darwin-amd64.tar.gz",
       "checksum": "f41bc914a721ac98a187df824b3b40f0a7f35bfb3c6d31221bdd940d537d3c28",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.8.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.freebsd-386.tar.gz",
       "checksum": "029219c9588fd6af498898e783963c7ce3489270304987c561990d8d01169d7b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.8.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.freebsd-amd64.tar.gz",
       "checksum": "fc1ab404793cb9322e6e7348c274bf7d3562cc8bfb7b17e3b7c6e5787c89da2b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.8.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.linux-386.tar.gz",
       "checksum": "10202da0b7f2a0f2c2ec4dd65375584dd829ce88ccc58e5fe1fa1352e69fecaf",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.8.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.linux-amd64.tar.gz",
       "checksum": "d8626fb6f9a3ab397d88c483b576be41fa81eefcec2fd18562c87626dbb3c39e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.10.8.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.linux-arm64.tar.gz",
       "checksum": "0921a76e78022ec2ae217e85b04940e2e9912b4c3218d96a827deedb9abe1c7b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.10.8.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.linux-armv6l.tar.gz",
       "checksum": "6fdbc67524fc4c15fc87014869dddce9ecda7958b78f3cb1bbc5b0a9b61bfb95",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.10.8.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.linux-ppc64le.tar.gz",
       "checksum": "9054bcc7582ebb8a69ca43447a38e4b9ea11d08f05511cc7f13720e3a12ff299",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.10.8.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.10.8.linux-s390x.tar.gz",
       "checksum": "6f71b189c6cf30f7736af21265e992990cb0374138b7a70b0880cf8579399a69",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.10.8.windows-386.zip",
+      "url": "https://golang.org/dl/go1.10.8.windows-386.zip",
       "checksum": "9ded97d830bef3734ea6de70df0159656d6a63e01484175b34d72b8db326bda0",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.10.8.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.10.8.windows-amd64.zip",
       "checksum": "ab63b55c349f75cce4b93aefa9b52828f50ebafb302da5057db0e686d7873d7a",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -712,77 +712,77 @@
   ],
   "1.11": [
     {
-      "url": "/dl/go1.11.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.darwin-amd64.tar.gz",
       "checksum": "9749e6cb9c6d05cf10445a7c9899b58e72325c54fee9783ed1ac679be8e1e073",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.freebsd-386.tar.gz",
       "checksum": "e4c2a9bd43932cb8f3226e866737e4a0f8cdda93db9d82754a0ffea04af1a259",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.freebsd-amd64.tar.gz",
       "checksum": "535a7561a229bfe7bece68c8e315421fd9fbbd3a599b461944113c8d8240b28f",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.linux-386.tar.gz",
       "checksum": "1a91932b65b4af2f84ef2dce10d790e6a0d3d22c9ea1bdf3d8c4d9279dfa680e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.linux-amd64.tar.gz",
       "checksum": "b3fcf280ff86558e0559e185b601c9eade0fd24c900b4c63cd14d1d38613e499",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.linux-arm64.tar.gz",
       "checksum": "e4853168f41d0bea65e4d38f992a2d44b58552605f623640c5ead89d515c56c9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.linux-armv6l.tar.gz",
       "checksum": "8ffeb3577d8ca5477064f1cb8739835973c866487f2bf81df1227eaa96826acd",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.linux-ppc64le.tar.gz",
       "checksum": "e874d617f0e322f8c2dda8c23ea3a2ea21d5dfe7177abb1f8b6a0ac7cd653272",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.linux-s390x.tar.gz",
       "checksum": "c113495fbb175d6beb1b881750de1dd034c7ae8657c30b3de8808032c9af0a15",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.windows-386.zip",
       "checksum": "d3279f0e3d728637352eff0aa1e11268a0eb01f13644bcbce1c066139f5a90db",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.windows-amd64.zip",
       "checksum": "29f9291270f0b303d0b270f993972ead215b1bad3cc674a0b8a09699d978aeb4",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -791,77 +791,77 @@
   ],
   "1.11.1": [
     {
-      "url": "/dl/go1.11.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.darwin-amd64.tar.gz",
       "checksum": "1f2b29c8b08a140f06c88d055ad68104ccea9ca75fd28fbc95fe1eeb61a29bef",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.freebsd-386.tar.gz",
       "checksum": "db02787955495a4128811705dabf1b09c6d9674d59ebf93bc7be40a1ead7d91f",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.freebsd-amd64.tar.gz",
       "checksum": "b2618f92bf5365c3e4f2a1f82997505d6356364310fdc0b9137734c4c9df29d8",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.linux-386.tar.gz",
       "checksum": "52935db83719739d84a389a8f3b14544874fba803a316250b8d596313283aadf",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.linux-amd64.tar.gz",
       "checksum": "2871270d8ff0c8c69f161aaae42f9f28739855ff5c5204752a8d92a1c9f63993",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.1.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.linux-arm64.tar.gz",
       "checksum": "25e1a281b937022c70571ac5a538c9402dd74bceb71c2526377a7e5747df5522",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.linux-armv6l.tar.gz",
       "checksum": "bc601e428f458da6028671d66581b026092742baf6d3124748bb044c82497d42",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.1.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.linux-ppc64le.tar.gz",
       "checksum": "f929d434d6db09fc4c6b67b03951596e576af5d02ff009633ca3c5be1c832bdd",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.1.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.1.linux-s390x.tar.gz",
       "checksum": "93afc048ad72fa2a0e5ec56bcdcd8a34213eb262aee6f39a7e4dfeeb7e564c9d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.1.windows-386.zip",
       "checksum": "5cc3681c954e23d40b0c2565765ec34f4b4e834348e03e1d1e6fd1c3a75b8202",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.1.windows-amd64.zip",
       "checksum": "230a08d4260ded9d769f072512a49bffe8bfaff8323e839c2db7cf7c9c788130",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -870,77 +870,77 @@
   ],
   "1.11.10": [
     {
-      "url": "/dl/go1.11.10.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.darwin-amd64.tar.gz",
       "checksum": "194d7ce2b88a791147be64860f21bac8eeec8f372c9e9caab6c72c3bd525a039",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.10.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.freebsd-386.tar.gz",
       "checksum": "5e90549194981e78a6d222c9a1f882952309f36fc93021173a1c179ec292de03",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.10.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.freebsd-amd64.tar.gz",
       "checksum": "cccd4951358735d0acb7e67e8db842062a51f348c471d222d7b9b1e87877e109",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.10.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.linux-386.tar.gz",
       "checksum": "619ddab5b56597d72681467810c63238063ab0d221fe0df9b2e85608c10161e5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.10.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.linux-amd64.tar.gz",
       "checksum": "aefaa228b68641e266d1f23f1d95dba33f17552ba132878b65bb798ffa37e6d0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.10.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.linux-arm64.tar.gz",
       "checksum": "6743c54f0e33873c113cbd66df7749e81785f378567734831c2e5d3b6b6aa2b8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.10.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.linux-armv6l.tar.gz",
       "checksum": "29812e3443c469de6b976e4e44b5e6402d55f6358a544278addc22446a0abe8b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.10.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.linux-ppc64le.tar.gz",
       "checksum": "a6c7129e92fe325645229846257e563dab1d970bb0e61820d63524df2b54fcf8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.10.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.10.linux-s390x.tar.gz",
       "checksum": "35f196abd74db6f049018829ea6230fde6b8c2e24d2da9f9e75ce0e6d0292b49",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.10.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.10.windows-386.zip",
       "checksum": "a74ca1c26c8c73a6b0843a82630da69f43e7f71aad8171a40e5872cc3b06913f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.10.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.10.windows-amd64.zip",
       "checksum": "e0354b5cef18dbf5867fff022ed4264c441df504f3cb86c90d8b987eca336f78",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -949,77 +949,77 @@
   ],
   "1.11.11": [
     {
-      "url": "/dl/go1.11.11.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.darwin-amd64.tar.gz",
       "checksum": "7b235cc8a51b68d2370e629aacb60226e5791e33f4c6bf2abb30b43817149450",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.11.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.freebsd-386.tar.gz",
       "checksum": "96be77e7f3bbe87bef174c4d2854c09cfe96d7c97888eb11a9702db6b5038320",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.11.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.freebsd-amd64.tar.gz",
       "checksum": "77e08891f254eb9b784427bcf1b2ec5bcf1bc53c1f6bcccf630a889a55df8f6d",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.11.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.linux-386.tar.gz",
       "checksum": "c711fe5025608e14bcd0efda9403e9b8f05cb4a53a125e296d639c10d280a65f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.11.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.linux-amd64.tar.gz",
       "checksum": "2fd47b824d6e32154b0f6c8742d066d816667715763e06cebb710304b195c775",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.11.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.linux-arm64.tar.gz",
       "checksum": "5ee39ea08e5d8c017658f36d0f969b17a44d49576214f4a00710f2d98bb773be",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.11.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.linux-armv6l.tar.gz",
       "checksum": "c2b882a5fbb3bac5c9cc6d65bfe17a5febfe0251a339fc059306bb825dec9b17",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.11.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.linux-ppc64le.tar.gz",
       "checksum": "98ff7ff2367239e26745231aabeaf9d7e51c40b616bb9aa15d4376792ff581d1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.11.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.11.linux-s390x.tar.gz",
       "checksum": "d7471874ed396f72dd550c3593c9f42d5e3d38a2cca7658e669305bf9023e6c8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.11.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.11.windows-386.zip",
       "checksum": "cbe55adb6f0748bfe8c0bbad8d42e311d0bd045300b5b3af2ff3a636211e359f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.11.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.11.windows-amd64.zip",
       "checksum": "38018a1a0fa341687cee2f71c0e7578f852bbf017ad48907cda6cc28d1b84140",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1028,77 +1028,77 @@
   ],
   "1.11.12": [
     {
-      "url": "/dl/go1.11.12.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.darwin-amd64.tar.gz",
       "checksum": "d2e1f708f3aef540ab27bcecd5c7e995c28e3a6db799d20393dd886ad3937a4c",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.12.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.freebsd-386.tar.gz",
       "checksum": "9d634ad1c815c5fe7845b982900205b91244c0a71b86d295f6c2d6ae0909edaa",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.12.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.freebsd-amd64.tar.gz",
       "checksum": "be3017c5a71858f7a850081dbcf9b2975ee824d0f31040ca31e2170022f76fd1",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.12.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.linux-386.tar.gz",
       "checksum": "8467e68d6ed6f6a95c6db6a1e352fc529f256bba0955eaef472e50cf4c0cba61",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.12.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.linux-amd64.tar.gz",
       "checksum": "14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.12.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.linux-arm64.tar.gz",
       "checksum": "d79c075773fc3121d0e719b83b46115efff685ade94545a52f3ac22f43d76196",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.12.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.linux-armv6l.tar.gz",
       "checksum": "5ffe422dc054909da4e468cb0df6e2cd41cebfe4fd9515f32bb3e3fbfc416016",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.12.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.linux-ppc64le.tar.gz",
       "checksum": "92bd4dc0dc8227fb22ad88545dd72669923019760cd640d4cca189860870561a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.12.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.12.linux-s390x.tar.gz",
       "checksum": "a4d100a1c92e50fd9b8a4d529da0ef0f4509c72643d6fb481918fd543f5871c0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.12.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.12.windows-386.zip",
       "checksum": "de4e2046d9e7afee0787fb72d0e4280bd684c67757a360ef9060083ab20f2c73",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.12.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.12.windows-amd64.zip",
       "checksum": "a86e41e06d39f68ea8fa6a7765ce529abe3ec5037ba3a3bff2e6d25455a4fa34",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1107,77 +1107,77 @@
   ],
   "1.11.13": [
     {
-      "url": "/dl/go1.11.13.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.darwin-amd64.tar.gz",
       "checksum": "43b7b4a4c7f1729132dafbc2452e7838e1808ee759bd11f4f0359c82182589bc",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.13.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.freebsd-386.tar.gz",
       "checksum": "930ba8e7122f3304600e4e28c02aa91b0899d6d48de34d575da34393b8bb6201",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.13.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.freebsd-amd64.tar.gz",
       "checksum": "02e42d47da46b250ee5aa0b8e1d5aff097adee5ad6be9d7963ad57a005878fca",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.13.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.linux-386.tar.gz",
       "checksum": "282e20167a7aaaba7b23de980696e1944a004efd0079e80d675d66b263ef595b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.13.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.linux-amd64.tar.gz",
       "checksum": "50fe8e13592f8cf22304b9c4adfc11849a2c3d281b1d7e09c924ae24874c6daa",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.13.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.linux-arm64.tar.gz",
       "checksum": "e94329c97b38b5bffe9c18e84e9f521dc995e02df7696897a7626293da9ac593",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.13.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.linux-armv6l.tar.gz",
       "checksum": "513eb46158917662e1588cb89f51d11839730e46847778646c36c69c687bfdc5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.13.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.linux-ppc64le.tar.gz",
       "checksum": "ad3c7397ddd41a5af9d9bf3c560d3d0f8c1bdef4ac4d21819a021ea88e25efca",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.13.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.13.linux-s390x.tar.gz",
       "checksum": "bd00bd27e641450f165a37a83f1e83a4ef3c626ef5675b77184e9c0147257657",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.13.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.13.windows-386.zip",
       "checksum": "50adc8ab5d41ad16ebde3fa657b91349838d534e43d55a2b9123b81973849230",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.13.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.13.windows-amd64.zip",
       "checksum": "55752de84439d0ed744ad681ae0915314516e69091fb86cab9701628ce3a65ff",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1186,77 +1186,77 @@
   ],
   "1.11.2": [
     {
-      "url": "/dl/go1.11.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.darwin-amd64.tar.gz",
       "checksum": "be2a9382ef85792280951a78e789e8891ddb1df4ac718cd241ea9d977c85c683",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.freebsd-386.tar.gz",
       "checksum": "7daf8c1995e6eb343c4b487ba4d6b8fb5463cdead8a8bde867a25cc7168ff77b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.freebsd-amd64.tar.gz",
       "checksum": "a0b46726b102067bdd9a9b863f2bce4d23e4478118162bb9b2362733eb28cabf",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.linux-386.tar.gz",
       "checksum": "e74f2f37b43b9b1bcf18008a11e0efb8921b41dff399a4f48ac09a4f25729881",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.linux-amd64.tar.gz",
       "checksum": "1dfe664fa3d8ad714bbd15a36627992effd150ddabd7523931f077b3926d736d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.2.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.linux-arm64.tar.gz",
       "checksum": "98a42b9b8d3bacbcc6351a1e39af52eff582d0bc3ac804cd5a97ce497dd84026",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.2.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.linux-armv6l.tar.gz",
       "checksum": "b9d16a8eb1f7b8fdadd27232f6300aa8b4427e5e4cb148c4be4089db8fb56429",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.2.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.linux-ppc64le.tar.gz",
       "checksum": "23291935a299fdfde4b6a988ce3faa0c7a498aab6d56bbafbf1e7476468529a3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.2.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.2.linux-s390x.tar.gz",
       "checksum": "a67ef820ef8cfecc8d68c69dd5bf513aaf647c09b6605570af425bf5fe8a32f0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.2.windows-386.zip",
       "checksum": "c0c5ab568d9cf260cd7d281e0a489ef91f4b943813d99dac78b61607dca17283",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.2.windows-amd64.zip",
       "checksum": "086c59df0dce54d88f30edd50160393deceb27e73b8d6b46b9ee3f88b0c02e28",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1265,77 +1265,77 @@
   ],
   "1.11.3": [
     {
-      "url": "/dl/go1.11.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.darwin-amd64.tar.gz",
       "checksum": "3d164d44fcb06a4bbd69d19d8d91308d601f7d855a1037346389644803fdf148",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.freebsd-386.tar.gz",
       "checksum": "2b4aacf3dc09c8b210fe3daf00f7c17c97d29503070200ba46e04f2d93790672",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.freebsd-amd64.tar.gz",
       "checksum": "29b3fcc8d80ac1ea10cd82ca78d3dac4e7242333b882855ea7bc8e3a9d974116",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.linux-386.tar.gz",
       "checksum": "c3fadf7f8652c060e18b7907fb8e15b853955b25aa661dbd991f6d6bc581d7a9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.linux-amd64.tar.gz",
       "checksum": "d20a4869ffb13cee0f7ee777bf18c7b9b67ef0375f93fac1298519e0c227a07f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.3.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.linux-arm64.tar.gz",
       "checksum": "723c54cb081dd629a44d620197e4a789dccdfe6dee7f8b4ad7a6659f76952056",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.linux-armv6l.tar.gz",
       "checksum": "384933e6e97b74c5125011c8f0539362bbed5a015978a34e441d7333d8e519b9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.3.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.linux-ppc64le.tar.gz",
       "checksum": "57c89a047ef4f539580af4cadebf1364a906891b065afa0664592e72a034b0ee",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.3.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.3.linux-s390x.tar.gz",
       "checksum": "183258709c051ceb2900dee5ee681abb0bc440624c8f657374bde2a5658bef27",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.3.windows-386.zip",
       "checksum": "07a38035d642ae81820551ce486f2ac7d541c0caf910659452b4661656db0691",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.3.windows-amd64.zip",
       "checksum": "bc168207115eb0686e226ed3708337b161946c1acb0437603e1221e94f2e1f0f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1344,77 +1344,77 @@
   ],
   "1.11.4": [
     {
-      "url": "/dl/go1.11.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.darwin-amd64.tar.gz",
       "checksum": "48ea987fb610894b3108ecf42e7a4fd1c1e3eabcaeb570e388c75af1f1375f80",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.freebsd-386.tar.gz",
       "checksum": "7c302a5fcb25c7a4d370e856218b748994bbb129810306260293cdfba0a80650",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.freebsd-amd64.tar.gz",
       "checksum": "e5a99add3e60e38ef559e211584bb09a883ccc46a6fb1432dcaa9fd052689b71",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.linux-386.tar.gz",
       "checksum": "cecd2da1849043237d5f0756a93d601db6798fa3bb27a14563d201088aa415f3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.linux-amd64.tar.gz",
       "checksum": "fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.4.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.linux-arm64.tar.gz",
       "checksum": "b76df430ba8caff197b8558921deef782cdb20b62fa36fa93f81a8c08ab7c8e7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.linux-armv6l.tar.gz",
       "checksum": "9f7a71d27fef69f654a93e265560c8d9db1a2ca3f1dcdbe5288c46facfde5821",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.linux-ppc64le.tar.gz",
       "checksum": "1f10146826acd56716b00b9188079af53823ddd79ceb6362e78e2f3aafb370ab",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.4.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.4.linux-s390x.tar.gz",
       "checksum": "4467442dacf89eb94c5d6f9f700204cb360be82db60e6296cc2ef8d0e890cd42",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.4.windows-386.zip",
       "checksum": "bc25ea25406878986f91c92ae802f25f033cb0163b4aeac7e7185f71d0ede788",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.4.windows-amd64.zip",
       "checksum": "eeb20e21702f2b9469d9381df5de85e2f731b64a1f54effe196d0f7d0227fe14",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1423,77 +1423,77 @@
   ],
   "1.11.5": [
     {
-      "url": "/dl/go1.11.5.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.darwin-amd64.tar.gz",
       "checksum": "b970d8fdd5245193073395ce7b7775dd9deea980d4ce5e68b3b80ee9edcf2afc",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.5.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.freebsd-386.tar.gz",
       "checksum": "29d208de22cf4561404f4e4866cbb3d937d1043ce65e0a4e4bb88a8c8ac754ea",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.5.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.freebsd-amd64.tar.gz",
       "checksum": "edd594da33d497a3499b362af3a3b3281c2e1de2b68b869154d4151aa82d85e2",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.5.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.linux-386.tar.gz",
       "checksum": "acd8e05f8d3eed406e09bb58eab89de3f0a139d4aef15f74adeed2d2c24cb440",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.5.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.linux-amd64.tar.gz",
       "checksum": "ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.5.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.linux-arm64.tar.gz",
       "checksum": "6ee9a5714444182a236d3cc4636e74cfc5e24a1bacf0463ac71dcf0e7d4288ed",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.5.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.linux-armv6l.tar.gz",
       "checksum": "b26b53c94923f78955236386fee0725ef4e76b6cb47e0df0ed0c0c4724e7b198",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.5.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.linux-ppc64le.tar.gz",
       "checksum": "66e83152c68cb35d41f21453377d6a811585c9e01a6ac54b19f7a6e2cbb3d1f5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.5.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.5.linux-s390x.tar.gz",
       "checksum": "56209e5498c64a8338cd6f0fe0c2e2cbf6857c0acdb10c774894f0cc0d19f413",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.5.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.5.windows-386.zip",
       "checksum": "b569f7a45056ab810364d7ac9ee6357e9a098fc3e4c75e016948736fa93ee229",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.5.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.5.windows-amd64.zip",
       "checksum": "1c734fe614fa052f44694e993f2d06f24a56b6703ee46fdfb2b9bf277819fe40",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1502,77 +1502,77 @@
   ],
   "1.11.6": [
     {
-      "url": "/dl/go1.11.6.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.darwin-amd64.tar.gz",
       "checksum": "3f1d8af129ee362990b98ba8a77ed9a595fd497d4c934e01d8cdd902d18cc97a",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.6.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.freebsd-386.tar.gz",
       "checksum": "7a9e639ab153e86b9202193255b2ab21708ea2a5078735c1fe6a7023b7e104b0",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.6.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.freebsd-amd64.tar.gz",
       "checksum": "27cfee907a4d83614b8ffeb122a3e238821c9e9287d04c126658c635cc91a5c7",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.6.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.linux-386.tar.gz",
       "checksum": "7d90e484bb92e68648c1a7b6b1790e97af33718bae457d2ee02ee5d1dd0ce2b7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.6.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.linux-amd64.tar.gz",
       "checksum": "4e1864282d8d20010d6385a12a1e35641783a380a7c57907bfb46a5499c5eb49",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.6.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.linux-arm64.tar.gz",
       "checksum": "29f64505cea47c57a46e2c8001ecf8d0c01cbf1ec86de96f4e3126b94a12ebb7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.6.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.linux-armv6l.tar.gz",
       "checksum": "62597fe72f1170cbb939958823555a701510e00362eb8a10b7ace6e59c8e7e6e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.6.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.linux-ppc64le.tar.gz",
       "checksum": "43d7cc7d3cdc1e57af33a13296b48713735f55e25aa655187afb19a707143c77",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.6.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.6.linux-s390x.tar.gz",
       "checksum": "c7f83fa5975a8f11641962bad79f89a7e17a6580d0d21ca828733dc0cfe470f7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.6.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.6.windows-386.zip",
       "checksum": "11a2903eb117820931a995b3288b66aa2c176f6c45def12c854fecf4d9c7f69b",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.6.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.6.windows-amd64.zip",
       "checksum": "a91a1efb00028b222445f4bcb6c84548bbd74962e53c87b68f0bce65de29c1ae",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1581,77 +1581,77 @@
   ],
   "1.11.7": [
     {
-      "url": "/dl/go1.11.7.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.darwin-amd64.tar.gz",
       "checksum": "61059849b936e4987d0ad800c05357624cd2085748e3889c0ea29def4f0275ae",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.7.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.freebsd-386.tar.gz",
       "checksum": "2e64f5b1510ba3789114d8853dcbfb8cfaac87323352c4dd06d9f95dbbecc2f3",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.7.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.freebsd-amd64.tar.gz",
       "checksum": "30d99a0934d44878608dea3de8db59824ed56881c517a273450d7ba0cc124090",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.7.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.linux-386.tar.gz",
       "checksum": "86d11a58bd99298719cb7ebea160255aefc56735d14089d2b2241d581967a482",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.7.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.linux-amd64.tar.gz",
       "checksum": "db687814288b3b541c1754dfd4ecc2b8fd0d5e7995624945e3054a350ca573d8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.7.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.linux-arm64.tar.gz",
       "checksum": "fe7ba5046aa4f52ae8fa36531aac4a949ad8e10c02b0f4aa05a420b4e803f8c6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.7.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.linux-armv6l.tar.gz",
       "checksum": "7d6ae2e119a432a4b00a6dc2c2085f56ead4973f40d58e534308f1535b45afc2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.7.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.linux-ppc64le.tar.gz",
       "checksum": "43b04f58b37808f86f526e6f1a8d6643fe196c1314acc3d7db710ec9ae960d18",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.7.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.7.linux-s390x.tar.gz",
       "checksum": "178932743c7af70c94f170f800202f490e0f85e74796dabe0a23d50630ba0333",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.7.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.7.windows-386.zip",
       "checksum": "ae166b92ce5f2d878e5f375685bfbce6322f72bdbd98b2ec710f2449faeca3a8",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.7.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.7.windows-amd64.zip",
       "checksum": "7d2a8f2f90f4e989bd3fcb8ab70949a0a3cdb0ed416cd9f61768b4cfc214c09e",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1660,77 +1660,77 @@
   ],
   "1.11.8": [
     {
-      "url": "/dl/go1.11.8.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.darwin-amd64.tar.gz",
       "checksum": "2bbd6ddc3e74bbadc2d2700a9372be1a82816b3de6c6c4915825d631c317c11d",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.8.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.freebsd-386.tar.gz",
       "checksum": "ff029f93abde0880c201789389e4da0c43bdf8cddd45b6ddb1c999db33e40190",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.8.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.freebsd-amd64.tar.gz",
       "checksum": "e5183aedcf3a8e1a5acb608833d2652c24d450c4b00b51a94be352190e272a26",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.8.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.linux-386.tar.gz",
       "checksum": "e0e62a02516fa2197a2eb319a6957e7bd7007005a11b4da5c6650879999db899",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.8.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.linux-amd64.tar.gz",
       "checksum": "e32ab1c934b747999d04e8a550b97f4647f8b1b43e152de5650d4476bfd1d2e1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.8.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.linux-arm64.tar.gz",
       "checksum": "68c42239d118b27f5e52a449f444c8a53e64a181b12d9ecbda14d0c3b765a5ee",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.8.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.linux-armv6l.tar.gz",
       "checksum": "c5d4fd90242761c214124eedb0ffc35af52be19e7a4eb4006b036b5dcb422c87",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.8.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.linux-ppc64le.tar.gz",
       "checksum": "4f0559832957c37022f771420902c1f19100c0a5b391c4957753c521a9eba56e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.8.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.8.linux-s390x.tar.gz",
       "checksum": "023928ee1d896af181c62acfd0a4e7bd713c8503a9b3b9aec745a3a830630e1b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.8.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.8.windows-386.zip",
       "checksum": "4c9e043790d9f477f23a90ac8cfbaffa46953ee8ba888152cf5b72a249688e6f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.8.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.8.windows-amd64.zip",
       "checksum": "6b9d9f18ace455dcec2e72a0c6740fb23fe5f39433df3522b76ce05dcdcb1808",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1739,77 +1739,77 @@
   ],
   "1.11.9": [
     {
-      "url": "/dl/go1.11.9.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.darwin-amd64.tar.gz",
       "checksum": "6b842edbd72ffc0c1243a8f4bbbc8b0fd0b44dd0176b0203eb8ebf9dd7057006",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.9.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.freebsd-386.tar.gz",
       "checksum": "2f58d4fb7d94cd0947f36d9422e20a3d4aba95dd3eec9826a9828194a13eb8a5",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.9.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.freebsd-amd64.tar.gz",
       "checksum": "10da27ca2ab83399417e08ad78b5770de594c96c1cdb809d2d8df4d36959f263",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.9.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.linux-386.tar.gz",
       "checksum": "0fa4001fcf1ef0644e261bf6dde02fc9f10ae4df6d74fda61fc4d3c3cbef1d79",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.9.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.linux-amd64.tar.gz",
       "checksum": "e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.11.9.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.linux-arm64.tar.gz",
       "checksum": "892ab6c2510c4caa5905b3b1b6a1d4c6f04e384841fec50881ca2be7e8accf05",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.11.9.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.linux-armv6l.tar.gz",
       "checksum": "f0d7b039cae61efdc346669f3459460e3dc03b6c6de528ca107fc53970cba0d1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.11.9.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.linux-ppc64le.tar.gz",
       "checksum": "6a0a6a80997529543a434667f404ead2da88ac8fecc59bfba82f62bd2588e6c8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.11.9.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.11.9.linux-s390x.tar.gz",
       "checksum": "0dd7073469d0f414b264fbadc4f720f9582b13ff6a0a978a9ef23020f9e42ac1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.11.9.windows-386.zip",
+      "url": "https://golang.org/dl/go1.11.9.windows-386.zip",
       "checksum": "ce999ecbd89375592de1536718be4307fbc9fdccde860a5cc388b5d471b6af59",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.11.9.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.11.9.windows-amd64.zip",
       "checksum": "f3f3e3c428131d5be65d79cf8663b3a81b6675e5cf9780c3b0769cfca6824922",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1818,77 +1818,77 @@
   ],
   "1.12": [
     {
-      "url": "/dl/go1.12.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.darwin-amd64.tar.gz",
       "checksum": "6c7e07349403f71588ef4e93a6d4ae31f8e5de1497a0a42fd998fe9b6bd07c8e",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.freebsd-386.tar.gz",
       "checksum": "5f66cc122e91249d9b371b2c8635b0b50db513812e3efaf9d6defbc28bff3a1c",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.freebsd-amd64.tar.gz",
       "checksum": "b4c063a3f39de4f837475cb982507926d7cab4f64d35e1dc0d6dce555b3fe143",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.linux-386.tar.gz",
       "checksum": "3ac1db65a6fa5c13f424b53ee181755429df0c33775733cede1e0d540440fd7b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.linux-amd64.tar.gz",
       "checksum": "750a07fef8579ae4839458701f4df690e0b20b8bcce33b437e4df89c451b6f13",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.linux-arm64.tar.gz",
       "checksum": "b7bf59c2f1ac48eb587817a2a30b02168ecc99635fc19b6e677cce01406e3fac",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.linux-armv6l.tar.gz",
       "checksum": "ea0636f055763d309437461b5817452419411eb1f598dc7f35999fae05bcb79a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.linux-ppc64le.tar.gz",
       "checksum": "5be21e7035efa4a270802ea04fb104dc7a54e3492641ae44632170b93166fb68",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.linux-s390x.tar.gz",
       "checksum": "c0aef360b99ebb4b834db8b5b22777b73a11fa37b382121b24bf587c40603915",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.windows-386.zip",
       "checksum": "c6606bfdc4d8b080fc40f72a072eb380ead77a02a4f99a6b953df6d9c7029970",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.windows-amd64.zip",
       "checksum": "880ced1aecef08b3471a84381b6c7e2c0e846b81dd97ecb629b534d941f282bd",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1897,77 +1897,77 @@
   ],
   "1.12.1": [
     {
-      "url": "/dl/go1.12.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.darwin-amd64.tar.gz",
       "checksum": "1a3d311d77bc685a23f6243a1cb8c52538c4f976239c27dda2d2820225eb8fc9",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.freebsd-386.tar.gz",
       "checksum": "392724db9f1cf38630a5ae7ee5c67f1416e8715500298cf81eb777fc4e6858c1",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.freebsd-amd64.tar.gz",
       "checksum": "aecf1590f5ddbecc506d9e3941df95ecca71e779b1d52b0be82f7f0c14ba2abe",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.linux-386.tar.gz",
       "checksum": "af74b6572dd0c133e5de121928616eab60a6252c66f6d9b15007c82207416a2c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.linux-amd64.tar.gz",
       "checksum": "2a3fdabf665496a0db5f41ec6af7a9b15a49fbe71a85a50ca38b1f13a103aeec",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.1.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.linux-arm64.tar.gz",
       "checksum": "10dba44cf95c7aa7abc3c72610c12ebcaf7cad6eed761d5ad92736ca3bc0d547",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.linux-armv6l.tar.gz",
       "checksum": "ceac33f07f8fdbccd6c6f7339db33479e1be8c206e67458ba259470fe796dbf2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.1.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.linux-ppc64le.tar.gz",
       "checksum": "e1258c81f420c88339abf40888423904c0023497b4e9bbffac9ee484597a57d3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.1.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.1.linux-s390x.tar.gz",
       "checksum": "a9b8f49be6b2083e2586c2ce8a2a86d5dbf47cca64ac6195546a81c9927f9513",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.1.windows-386.zip",
       "checksum": "f424dd3340c5739a87cfd1f836d387df69cecddce2a94f14a057261bb7068172",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.1.windows-amd64.zip",
       "checksum": "2f4849b512fffb2cf2028608aa066cc1b79e730fd146c7b89015797162f08ec5",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -1976,77 +1976,77 @@
   ],
   "1.12.10": [
     {
-      "url": "/dl/go1.12.10.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.darwin-amd64.tar.gz",
       "checksum": "a9d98865652c471c2ffb8b9148ebfa69e0393af43a091555b326c72d8c227657",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.10.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.freebsd-386.tar.gz",
       "checksum": "8ab16e116ae668db577464ce3f5084ea0889db8310652acf022947c4b628ac75",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.10.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.freebsd-amd64.tar.gz",
       "checksum": "47e60ab46c8c24876f26c17d3f856e0d1a272f0a07971a74e26cfa3048b54a21",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.10.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.linux-386.tar.gz",
       "checksum": "863ad8abc9a9a18a9d55e2a3a2c68046ae57ccd34c2fa0159b70d015957391d6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.10.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.linux-amd64.tar.gz",
       "checksum": "aaa84147433aed24e70b31da369bb6ca2859464a45de47c2a5023d8573412f6b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.10.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.linux-arm64.tar.gz",
       "checksum": "d45d1eebe10a33a3d850cafcefd45200091a9ddb880857135307ee0de9424d24",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.10.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.linux-armv6l.tar.gz",
       "checksum": "b20a897e3a078637a91e8c91ff69a27bcefea7384a0019e56fbfd21f8170fe6b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.10.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.linux-ppc64le.tar.gz",
       "checksum": "9c5787aeca109c6f90f0ef82328f9ec8d54cf5a4a51d23bfedfc440e92649f9d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.10.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.10.linux-s390x.tar.gz",
       "checksum": "a8ab50d133db183d9afa304f79c9e994c9208aec9d1bf14b04cd2bda478f406a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.10.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.10.windows-386.zip",
       "checksum": "577aebddb488d9010a4d6bbd19c2ea282ff5f05013eecda84a3fbf7fd8c9f770",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.10.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.10.windows-amd64.zip",
       "checksum": "38ea3422a4b7e60a8959b1d6b570ecc28d8c39faefac0f79d1e7104ce3204967",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2055,77 +2055,77 @@
   ],
   "1.12.11": [
     {
-      "url": "/dl/go1.12.11.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.darwin-amd64.tar.gz",
       "checksum": "ab254d828a47b686a2625d3c4e29f3fe02d57caf297e94bc1fcf763cbbeb7f38",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.11.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.freebsd-386.tar.gz",
       "checksum": "a86b47261e85d7639b46e423ee01e43bba1cf6904c9b0a089386427947493669",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.11.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.freebsd-amd64.tar.gz",
       "checksum": "a97c00c0d135b939ade821fab8613ebe82563156fe575c837f76a1d3f9f0e6bd",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.11.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.linux-386.tar.gz",
       "checksum": "9d979c489471c5ec9b9cd6b0922f061b2dca7b801effc39d7826a1255e8221c9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.11.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.linux-amd64.tar.gz",
       "checksum": "2c5960292da8b747d83f171a28a04116b2977e809169c344268c893e4cf0a857",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.11.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.linux-arm64.tar.gz",
       "checksum": "a05361badb95f6cc5724e32f59b0f33048dfca63b539cf2bd8ab77fa4f2ba923",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.11.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.linux-armv6l.tar.gz",
       "checksum": "895766c9c1d1a32e9e0e7ea2f9fac6f33df0397954564c05b56ecdc58605fd1e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.11.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.linux-ppc64le.tar.gz",
       "checksum": "8f962f84bd36f5caad78710b32e074406d12e864e334bf6c8820836dbd1b6409",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.11.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.11.linux-s390x.tar.gz",
       "checksum": "faa9de31cc41c0ecb79382569f1269758a7e51ca526aaf849d7189da6e28f716",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.11.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.11.windows-386.zip",
       "checksum": "1d49f4178e2fc28e7da0d7640e96ca7aa013ab199a14658ec06ce62cc3057175",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.11.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.11.windows-amd64.zip",
       "checksum": "0b0c8dbcb9efa5f32c1249fc9c59ce0eb07d7a69b50ba48f0a713d0527231f2f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2134,77 +2134,77 @@
   ],
   "1.12.12": [
     {
-      "url": "/dl/go1.12.12.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.darwin-amd64.tar.gz",
       "checksum": "4fb0d6f9b09177f871c8fb5cd09d5d859a5de9e81b2322fd8f847b6d9a7e1bdb",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.12.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.freebsd-386.tar.gz",
       "checksum": "6b006fa12e59f2200d6ad0173f5074dce43fa503511da2fcf69528fdd9ff215b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.12.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.freebsd-amd64.tar.gz",
       "checksum": "709adccdd9ac3964c2dd52db5ce8de3c0f29e2d6b45b86d72ed509eaf0113e3d",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.12.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.linux-386.tar.gz",
       "checksum": "59a48035f9b1387347e8a8a0f7c6d693e6bc84e0374ef802fb8ec61f894db073",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.12.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.linux-amd64.tar.gz",
       "checksum": "4cf11ac6a8fa42d26ab85e27a5d916ee171900a87745d9f7d4a29a21587d78fc",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.12.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.linux-arm64.tar.gz",
       "checksum": "a7e2fed536904f2bf7007deed3609b3484c55660821bd2faaeb6928fa62fd33e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.12.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.linux-armv6l.tar.gz",
       "checksum": "ed3cda3c2d0648a712fa13cfc25e82431772231ef8f3db70de2fa9c2b893a5ab",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.12.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.linux-ppc64le.tar.gz",
       "checksum": "adee3f914baf578bd21526479f45f99782791dcd12bfba2a7ca2d3fb79e4d623",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.12.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.12.linux-s390x.tar.gz",
       "checksum": "24b0be352713a6e047b21093cf2aaaf22c7757d3606839ddd26da60e7f18dba6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.12.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.12.windows-386.zip",
       "checksum": "1884c77352d6b9e0fff2f01efe8ef09ea2886d95dc916e264872c8da24746457",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.12.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.12.windows-amd64.zip",
       "checksum": "2d030b382514a3c4b76dd0786f810ce50409cebaf311a6b79addc353627263a8",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2213,77 +2213,77 @@
   ],
   "1.12.13": [
     {
-      "url": "/dl/go1.12.13.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.darwin-amd64.tar.gz",
       "checksum": "6d3de6f7d7c0e8162aaa009128839fa5afcba578dcbd6ff034a82419d82480e9",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.13.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.freebsd-386.tar.gz",
       "checksum": "aad712bd70b34bb8d72f9a3add12a2520f81cdd45a5763650b44361982b51133",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.13.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.freebsd-amd64.tar.gz",
       "checksum": "0b0560747a5bf2646a339cbd899aae6d97c4057d516ede1fa3d8b509e9346725",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.13.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.linux-386.tar.gz",
       "checksum": "fafcb585591557b7b16d9b22dec4654193d205cf444b1810ab2988f658585e23",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.13.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.linux-amd64.tar.gz",
       "checksum": "da036454cb3353f9f507f0ceed4048feac611065e4e1818b434365eb32ac9bdc",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.13.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.linux-arm64.tar.gz",
       "checksum": "dcfcb3785292c98f7a75c2276169dfe2d445c19f8ffe1d40b3f7b8f59712d361",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.13.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.linux-armv6l.tar.gz",
       "checksum": "bf061cc3d4951e07904496b5c3d6c82419309d24634835522d786673a3f5438f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.13.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.linux-ppc64le.tar.gz",
       "checksum": "77056264abcf5444ed0d9ab7552552ae2145ca8fb6c39d33db3c735eaf3f42d2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.13.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.13.linux-s390x.tar.gz",
       "checksum": "8ef1ffbe7d0e944a52aadd529fc88fd6a2303ec67ee7eeb906712ca38ada0c91",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.13.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.13.windows-386.zip",
       "checksum": "b3cd68a8a1dfcb565377a32eae6ec6897a19d49282b5c6a5b4cbb628ec49a5d5",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.13.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.13.windows-amd64.zip",
       "checksum": "c441a298e8b510d3cdabfd361885cd6762e33eaceb27cbb0eabe6757f9d1f07d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2292,77 +2292,77 @@
   ],
   "1.12.14": [
     {
-      "url": "/dl/go1.12.14.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.darwin-amd64.tar.gz",
       "checksum": "b2ae6b0e328978df715b23f8531b484c67473074326d07985faae8a781c87c00",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.14.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.freebsd-386.tar.gz",
       "checksum": "8edea443b40209344018dd14ae2f534cedf68d5775283ebca764bf01302b05fe",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.14.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.freebsd-amd64.tar.gz",
       "checksum": "3a94a75572f9d2c1dbc1e830caef8a6ec9f2634d556c855a142c1f53f30b2575",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.14.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.linux-386.tar.gz",
       "checksum": "76dda90b4fc0410212094b433cfdc40c9802fba972427e95cbdec3c5b94fd7a6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.14.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.linux-amd64.tar.gz",
       "checksum": "925a1a9d8b31c2425d7313fe73d3342288968a66e26cd8bf1b6b5656f4603fcb",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.14.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.linux-arm64.tar.gz",
       "checksum": "1ab765f4cf74f05cfba40ddcea9160ca6cf9a57915036a559ca1691942862e7c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.14.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.linux-armv6l.tar.gz",
       "checksum": "c7aa5562168b6eb3a4bb54af061d68bcb6b9ecae9d785f9a38255c107c986b73",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.14.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.linux-ppc64le.tar.gz",
       "checksum": "4e237b1357922e186337989914201e98bd9aed855f4034a5918476650484f83d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.14.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.14.linux-s390x.tar.gz",
       "checksum": "affd9764e5b163591ca87f351984c17d74e518e03b9d5e16f2be57bd30a82c80",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.14.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.14.windows-386.zip",
       "checksum": "430f0fe3916202ef1a1573b69537af1e3866ab314528d80635c69a27b278b568",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.14.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.14.windows-amd64.zip",
       "checksum": "80f6ca5f5edd87bae7c009340148cd9828a61dd66de5ee7862843b0840afd4f4",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2371,77 +2371,77 @@
   ],
   "1.12.15": [
     {
-      "url": "/dl/go1.12.15.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.darwin-amd64.tar.gz",
       "checksum": "3a7afb588f3783545abb514d1d67ca27d33fb99ace69ff09880c2e76a0875d6e",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.15.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.freebsd-386.tar.gz",
       "checksum": "25b3a2f19d76ad0d3e9e43b79783759756b50aabcf6ac9c4bb3df75bf6e0d47c",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.15.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.freebsd-amd64.tar.gz",
       "checksum": "231a2be434fa1f7415ad8e92df3825a53910086392f43a7290da9be0439f701e",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.15.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.linux-386.tar.gz",
       "checksum": "608c9fb90b2b35f7b4e4b110a9c6919d8902311388c6309487b5f77aed9d2b74",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.15.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.linux-amd64.tar.gz",
       "checksum": "61068419f3d3fcd3cc415c352c4a93d6ae0e723ac18a22ac572b4904d78b5a4c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.15.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.linux-arm64.tar.gz",
       "checksum": "cff1a28f0b207dd54230bf822cdcfbcc7cd411261a9366616a05a1fa1fbeedd3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.15.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.linux-armv6l.tar.gz",
       "checksum": "3a36d168bf80c780694bf25d6cb2ed0dbb6d4bc29b1c82bb29e819d9dbe6347b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.15.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.linux-ppc64le.tar.gz",
       "checksum": "4fe9ce71a6cd9acd56f0e898dd87d95ed9bc83a6a5be0863e9b5b646e05eee05",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.15.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.15.linux-s390x.tar.gz",
       "checksum": "a02061245a738bc80c645251cddd7a22c1ea9fee0726d5caf5da7645dea3787e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.15.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.15.windows-386.zip",
       "checksum": "70723f28f73b9be4c2b835f9ac7867b5114d2d7d74ac0f863571914ab85a2a1a",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.15.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.15.windows-amd64.zip",
       "checksum": "80e7a471bef2a05d4729b38762b4534523ac4779c7b32d48ac85eaa490c111a5",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2450,77 +2450,77 @@
   ],
   "1.12.16": [
     {
-      "url": "/dl/go1.12.16.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.darwin-amd64.tar.gz",
       "checksum": "5d11cb80375f8758f90d5787b1e349604a9e38815fb1f8944322b3d4d2952180",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.16.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.freebsd-386.tar.gz",
       "checksum": "fd0632920773e1779588fc95e1864e74cd3d2df47712234717b06508b330f9b7",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.16.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.freebsd-amd64.tar.gz",
       "checksum": "3f0a65d47a51f4128556866d1a1f2b3b87674c91a7371fb2439672f9368a3f37",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.16.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.linux-386.tar.gz",
       "checksum": "e6ebf5622203f2ceee138af16c765818bf65b74668d5e73c1da6491c3e890a88",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.16.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.linux-amd64.tar.gz",
       "checksum": "bf3a85d75658144c06ce986ba05e07ef08af4320089b74b1d41de3b0f340ea7e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.16.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.linux-arm64.tar.gz",
       "checksum": "a01df310bfeffc67480982cf6ad50c9b83f9aaf4ac855d5e581b95eb727bb24c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.16.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.linux-armv6l.tar.gz",
       "checksum": "2f77688eaf25d8ae58adc5164de0fc13d600705c2ebadc6e1138e5ce9ceadc41",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.16.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.linux-ppc64le.tar.gz",
       "checksum": "7c133932d1beae68a483dbac69bb0e1023fa08196ebee100594b79c0672ce67c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.16.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.16.linux-s390x.tar.gz",
       "checksum": "e93326caefb3945054f9c98dd7934892b69dcb46d343cd3582c777874f5d2716",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.16.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.16.windows-386.zip",
       "checksum": "a9cf5bd6f8aca26ce941ef79497aa5a3bc445df40fb31b6ae4cb722ad148db56",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.16.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.16.windows-amd64.zip",
       "checksum": "d2a570e4872ba2260fb6369e2e9cc217e8f1541388d6f790520eeaf4447fef2f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2529,77 +2529,77 @@
   ],
   "1.12.17": [
     {
-      "url": "/dl/go1.12.17.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.darwin-amd64.tar.gz",
       "checksum": "a2f58b4bf10f3e882c1a43eba27a2aba65fc815384fbdfc46331c13bca5f5f24",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.17.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.freebsd-386.tar.gz",
       "checksum": "d097d90391154c238669881ddfffc1090e7760f70f89f2dc104e2a87118be6c7",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.17.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.freebsd-amd64.tar.gz",
       "checksum": "de4adf8157dc68149e9db895b2de827b356346842d12d47d0bbc1c79756ff347",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.17.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.linux-386.tar.gz",
       "checksum": "e33fc10c0486b02a019f120996d77792d8f19aae8bfdda97350a622a65d6b824",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.17.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.linux-amd64.tar.gz",
       "checksum": "a53dd476129d496047487bfd53d021dd17e0c96895865a0e7d0469ce3db8c8d2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.17.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.linux-arm64.tar.gz",
       "checksum": "9d0819cce1451abdb090071880fe8771f16a3bcee71d6f6906023d17799574e2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.17.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.linux-armv6l.tar.gz",
       "checksum": "a883c806fccb3eddb26da4a1a1f8536de863aee6807ed6c99606261877af7b99",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.17.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.linux-ppc64le.tar.gz",
       "checksum": "dca4df132da7579c352bccd9d6f4ecb8d8d61893a84b0feffcee2bb4246114a3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.17.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.17.linux-s390x.tar.gz",
       "checksum": "e50ffb6e0d7e7573ed9ca0f5228bdd43238a25ac34916de027036ff97322d236",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.17.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.17.windows-386.zip",
       "checksum": "f24af21ee3765b7d747c65811925de5f732f70edbeaaf4f4e75d8a5019a9ed6e",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.17.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.17.windows-amd64.zip",
       "checksum": "78ba5f19feaea1cf9327c8d3af69278a8476995d145ba57edd01ab5c1c6ecea7",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2608,77 +2608,77 @@
   ],
   "1.12.2": [
     {
-      "url": "/dl/go1.12.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.darwin-amd64.tar.gz",
       "checksum": "82f1c27fefeefb1dc42ed34cab32c2d826e111ade3418066e7049ba8046713f9",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.freebsd-386.tar.gz",
       "checksum": "8b642520509242472d48c8ab8ed7518410965c180e253691835a1faf2d8aa44f",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.freebsd-amd64.tar.gz",
       "checksum": "de534316c754819225549ad99fd52c56fe138f87d909c8fc109bba04db1c1400",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.linux-386.tar.gz",
       "checksum": "3005a7937ff2be7ea9badd416cc37dfe2ff589d3a311f1685de0a805e45455b6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.linux-amd64.tar.gz",
       "checksum": "f28c1fde8f293cc5c83ae8de76373cf76ae9306909564f54e0edcf140ce8fe3f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.2.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.linux-arm64.tar.gz",
       "checksum": "598558fe54bbdce8b676f81e37f514dd70b8fc1377086658ae6e836480e900eb",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.2.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.linux-armv6l.tar.gz",
       "checksum": "38d92116cd8c408e995972ff7fb0b6453c4f2214bde602d1772bd88f9d4d5c60",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.2.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.linux-ppc64le.tar.gz",
       "checksum": "62be1d5f38e322edc21de0debd3051247faff59890c343a7f2173c15098dbd35",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.2.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.2.linux-s390x.tar.gz",
       "checksum": "a41b0b11f5e34c3cccd7619bddf79a6d4b94bcbd2160fefcdf25f0afe87cad0a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.2.windows-386.zip",
       "checksum": "12d61e2b448709c6c3cc6b1bdff87f0f5a54ed0a515a130f9cee4384cde3c993",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.2.windows-amd64.zip",
       "checksum": "4197135ef2221c9d7772063e1bdcd3f51de37811b19a678db87d7fc735a218f9",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2687,77 +2687,77 @@
   ],
   "1.12.3": [
     {
-      "url": "/dl/go1.12.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.darwin-amd64.tar.gz",
       "checksum": "edb7aad4607509e3eb9f8bd3b43fb9c419b4a007874a9f6e2f99c541411f9304",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.freebsd-386.tar.gz",
       "checksum": "a8f01edb1d18469b49b45302560f60afdf0bc56794a20a50b87d902d0a4e3d47",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.freebsd-amd64.tar.gz",
       "checksum": "eee2439553351ae323152529c72fe831b892821dde6e1f4145526ca6aed63349",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.linux-386.tar.gz",
       "checksum": "67599ae0788ed88260531d4be4293cb8f5199e5c7e06d30c6bd95eb54f014be7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.linux-amd64.tar.gz",
       "checksum": "3924819eed16e55114f02d25d03e77c916ec40b7fd15c8acb5838b63135b03df",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.3.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.linux-arm64.tar.gz",
       "checksum": "4deb7f3b90d03f71f5cac3654e0e1f9cb46c45b85c5475510222b958e4ea2ed6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.linux-armv6l.tar.gz",
       "checksum": "efce59fac5ebc7302263ca1093fe2c3252c1b936f5b1ae08afc328eea0403c79",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.3.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.linux-ppc64le.tar.gz",
       "checksum": "8bd04e742be8ed3f7f6fd2c78e2303be2ee70709cdc28758f101765a5e7d6dc1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.3.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.3.linux-s390x.tar.gz",
       "checksum": "102fe607818ba21b9853ddfa3b1225b2af802010af3a032c6487144fbb7f3521",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.3.windows-386.zip",
       "checksum": "de3446df6f764030c5945800134c191f092dc14d2301f12fee6c8f611ac18829",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.3.windows-amd64.zip",
       "checksum": "1806e089e85b84f192d782a7f70f90a32e0eccfd181405857e612f806ec04059",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2766,77 +2766,77 @@
   ],
   "1.12.4": [
     {
-      "url": "/dl/go1.12.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.darwin-amd64.tar.gz",
       "checksum": "50af1aa6bf783358d68e125c5a72a1ba41fb83cee8f25b58ce59138896730a49",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.freebsd-386.tar.gz",
       "checksum": "8695afc656e75ecf72c6a9c617b0399bf864f4aa2b4017badbf98c5f56494244",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.freebsd-amd64.tar.gz",
       "checksum": "44f30606b1f2063bf1277f154b82910dbbe6183513aa8271391a320f45595e4b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.linux-386.tar.gz",
       "checksum": "eba5c51f657c1b05d5930475d1723758cd86db74499125ab48f0f9d1863845f7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.linux-amd64.tar.gz",
       "checksum": "d7d1f1f88ddfe55840712dc1747f37a790cbcaa448f6c9cf51bbe10aa65442f5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.4.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.linux-arm64.tar.gz",
       "checksum": "b7d7b4319b2d86a2ed20cef3b47aa23f0c97612b469178deecd021610f6917df",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.linux-armv6l.tar.gz",
       "checksum": "c43457b6d89016e9b79b92823003fd7858fb02aea22b335cfd204e0b5be71d92",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.linux-ppc64le.tar.gz",
       "checksum": "51642f3cd6ef9af6c4a092c2929e4fb478f102fe949921bd77ecd6905952c216",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.4.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.4.linux-s390x.tar.gz",
       "checksum": "0aab0f368c090da71f52531ebac977cc7396b692145acee557b3f9500b42467a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.4.windows-386.zip",
       "checksum": "4bc649c74c63aec9829523843669794b41e46f99bc78dd3a52f312604d36b165",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.4.windows-amd64.zip",
       "checksum": "25b043ebacca2fa2c87bbcd7463be5f34fbd225247c101888f81647fadbdfca0",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2845,77 +2845,77 @@
   ],
   "1.12.5": [
     {
-      "url": "/dl/go1.12.5.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.darwin-amd64.tar.gz",
       "checksum": "566d0b407f7d4aa5a1315988b562bbe4e9422a93ce2fbf27a664cddcb9a3e617",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.5.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.freebsd-386.tar.gz",
       "checksum": "b842330ad695bac9ea57d0a9d3aafaaf34921ec85702bccc2067f448e868332b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.5.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.freebsd-amd64.tar.gz",
       "checksum": "082acae7f5d2c780521f95fd177a08aacaccc0e38042d4ef981f7d7211a27b8a",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.5.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.linux-386.tar.gz",
       "checksum": "146605e13bf337ff3aacd941a816c5d97a8fef8b5817e07fcec4540632085980",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.5.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.linux-amd64.tar.gz",
       "checksum": "aea86e3c73495f205929cfebba0d63f1382c8ac59be081b6351681415f4063cf",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.5.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.linux-arm64.tar.gz",
       "checksum": "ff09f34935cd189a4912f3f308ec83e4683c309304144eae9cf60ebc552e7cd8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.5.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.linux-armv6l.tar.gz",
       "checksum": "311f5e76c7cec1ec752474a61d837e474b8e750b8e3eed267911ab57c0e5da9a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.5.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.linux-ppc64le.tar.gz",
       "checksum": "e88b2a2098bc79ad33912d1d27bc3282a7f3231b6f4672f306465bf46ff784ca",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.5.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.5.linux-s390x.tar.gz",
       "checksum": "168d297ec910cb446d1aea878baeb85f1387209f9eb55dde68bddcd4c006dcbb",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.5.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.5.windows-386.zip",
       "checksum": "9b8cfd668c182d39f2039bbb290cd062de438c7cc48ab3f4d9a326fce3538a03",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.5.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.5.windows-amd64.zip",
       "checksum": "ccb694279aab39fe0e70629261f13b0307ee40d2d5e1138ed94738023ab04baa",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -2924,77 +2924,77 @@
   ],
   "1.12.6": [
     {
-      "url": "/dl/go1.12.6.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.darwin-amd64.tar.gz",
       "checksum": "b12bbac3227e72c2964e638e85d6621996bd3c03e172e752334112c3f757ba6e",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.6.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.freebsd-386.tar.gz",
       "checksum": "5dcdffc8102ff1f53596b7cf0da83d66b1f3f59180e050cb299499aa731f68ac",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.6.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.freebsd-amd64.tar.gz",
       "checksum": "93a273bf283292142fc505bb18a3996e73009d9451c0c245b72013728da3f0af",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.6.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.linux-386.tar.gz",
       "checksum": "7aaf25164a9ab5e1005c15535ed16ee122df50ac192c2d79b7940315c2b74f2c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.6.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.linux-amd64.tar.gz",
       "checksum": "dbcf71a3c1ea53b8d54ef1b48c85a39a6c9a935d01fc8291ff2b92028e59913c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.6.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.linux-arm64.tar.gz",
       "checksum": "8f4e3909c74b4f3f3956715f32419b28d32a4ad57dbd79f74b7a8a920b21a1a3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.6.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.linux-armv6l.tar.gz",
       "checksum": "0708fbc125e7b782b44d450f3a3864859419b3691121ad401f1b9f00e488bddb",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.6.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.linux-ppc64le.tar.gz",
       "checksum": "67eacb68c1e251c1428e588776c5a02e287a508e3d44f940d31d8ff5d57f0eef",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.6.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.6.linux-s390x.tar.gz",
       "checksum": "c14baa10b87a38e56f28a176fae8a839e9052b0e691bdc0461677d4bcedea9aa",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.6.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.6.windows-386.zip",
       "checksum": "9d5644ef8e94ad0853e1a86d5465a4600fe5b2cedc946fff80de46135eab2486",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.6.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.6.windows-amd64.zip",
       "checksum": "9badf7bbc0ed55f2db967434b033a2cddf2e46dbdc5bb8560d8fde019e8e19d3",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3003,77 +3003,77 @@
   ],
   "1.12.7": [
     {
-      "url": "/dl/go1.12.7.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.darwin-amd64.tar.gz",
       "checksum": "282a8b54ea8339bbe0d34b8bdc1128511d04a6bd875ac8596bc6cac708e287ef",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.7.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.freebsd-386.tar.gz",
       "checksum": "588aee896fde2059b0e0941457f85ee1a0aa2cc8c7fa052bd6505f1e823551da",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.7.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.freebsd-amd64.tar.gz",
       "checksum": "3421c0461931e088ca26bfe6a401e96fca5797fef41297d712b115563d173e41",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.7.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.linux-386.tar.gz",
       "checksum": "ae2424b7ff557a708be12d3141f25b645966489ca49af1ad10b4fbe4c97d4c41",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.7.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.linux-amd64.tar.gz",
       "checksum": "66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.7.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.linux-arm64.tar.gz",
       "checksum": "4da1f7198a8fa0c4067852656b6c10153a4eca5a26aca28ef02ae9f4a7939ba5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.7.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.linux-armv6l.tar.gz",
       "checksum": "48edbe936e9eb74f259bfc4b621fafca4d4ec43156b4ee7bd0d979f257dcd60a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.7.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.linux-ppc64le.tar.gz",
       "checksum": "8eda20600d90247efbfa70d116d80056e11192d62592240975b2a8c53caa5bf3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.7.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.7.linux-s390x.tar.gz",
       "checksum": "3374ac3d646555e50be790091b51849319cfcb176904048458c7f4252337fce8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.7.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.7.windows-386.zip",
       "checksum": "bf55b97f5fd9f2fd9e4f0b182e296ee531262d1f8458169f8b42d989c2370e5c",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.7.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.7.windows-amd64.zip",
       "checksum": "502712c0e29edc6b9cda6fa5e4b6ff9b36e27d225373baead8708c9634aa8e50",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3082,77 +3082,77 @@
   ],
   "1.12.8": [
     {
-      "url": "/dl/go1.12.8.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.darwin-amd64.tar.gz",
       "checksum": "609c8d4913944c0836b0bb291de840dfa2cd45c733b1e50af7a18b1c00bc78f8",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.8.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.freebsd-386.tar.gz",
       "checksum": "707bfd48533fd5aece36fb479f9f895edf864b7d66baacf11d3035be6356a460",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.8.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.freebsd-amd64.tar.gz",
       "checksum": "9a1cb954a043e0f6d825acb0fb9d29d5a82cd9818a70212aa51cf6fbad58d35b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.8.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.linux-386.tar.gz",
       "checksum": "be164c4e04205c4fc713e81594bc2fdd4c94dff3d567ec8e0072223dd0778287",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.8.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.linux-amd64.tar.gz",
       "checksum": "bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.8.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.linux-arm64.tar.gz",
       "checksum": "15e9e0b5b414d1a0322896368c0050af6ab1cd82d050e93f8eceb38ef2626652",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.8.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.linux-armv6l.tar.gz",
       "checksum": "b6b057e7b5c740894132ce30e70503d7d36988dcd61a00f0865d1e7d6dcc74ca",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.8.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.linux-ppc64le.tar.gz",
       "checksum": "24a65f8a702ade1854f86ddf96eda554a8abd89c8a54ddc32788769419e90232",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.8.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.8.linux-s390x.tar.gz",
       "checksum": "db78fc8f9610cb27ac35aab55cb11698f4daa2101acdf46f0ba64e1db16323e5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.8.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.8.windows-386.zip",
       "checksum": "e07fec097549c4bba0cf5712723f459c56c812f29056707c16581684e45485f2",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.8.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.8.windows-amd64.zip",
       "checksum": "4352ed90240ddc1b6379adf3210b849b8e89a173ca00616f2beff53df9fef3c8",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3161,77 +3161,77 @@
   ],
   "1.12.9": [
     {
-      "url": "/dl/go1.12.9.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.darwin-amd64.tar.gz",
       "checksum": "4f189102b15de0be1852d03a764acb7ac5ea2c67672a6ad3a340bd18d0e04bb4",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.9.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.freebsd-386.tar.gz",
       "checksum": "d0d57f404c9741a92c8da35e8c1845461f11e8b6981892cd4f8713fef25e11fd",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.9.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.freebsd-amd64.tar.gz",
       "checksum": "1b63491d0c7a8d074f42c40716159b92b8d7fbe351c121bc16f5367cc81fdb82",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.9.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.linux-386.tar.gz",
       "checksum": "c40824a3e6c948b8ecad8fe9095b620c488b3d8d6694bdd48084a4798db4799a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.9.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.linux-amd64.tar.gz",
       "checksum": "ac2a6efcc1f5ec8bdc0db0a988bb1d301d64b6d61b7e8d9e42f662fbb75a2b9b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.12.9.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.linux-arm64.tar.gz",
       "checksum": "3606dc6ce8b4a5faad81d7365714a86b3162df041a32f44568418c9efbd7f646",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.12.9.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.linux-armv6l.tar.gz",
       "checksum": "0d9be0efa9cd296d6f8ab47de45356ba45cb82102bc5df2614f7af52e3fb5842",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.12.9.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.linux-ppc64le.tar.gz",
       "checksum": "2e74c071c6a68446c9b00c1717ceeb59a826025b9202b3b0efed4f128e868b30",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.12.9.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.12.9.linux-s390x.tar.gz",
       "checksum": "2aac6de8e83b253b8413781a2f9a0733384d859cff1b89a2ad0d13814541c336",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.12.9.windows-386.zip",
+      "url": "https://golang.org/dl/go1.12.9.windows-386.zip",
       "checksum": "96e54c9801973a255417d9827d470fd0fae14ad8c9274577012c01f97cd534dd",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.12.9.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.12.9.windows-amd64.zip",
       "checksum": "ec7550b32ff080b17060b9d4fde7bee94d9cf3c42e846e3a62fe4a3047ec79e3",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3240,77 +3240,77 @@
   ],
   "1.13": [
     {
-      "url": "/dl/go1.13.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.darwin-amd64.tar.gz",
       "checksum": "234ebbba1fbed8474340f79059cfb3af2a0f8b531c4ff0785346e0710e4003dd",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.freebsd-386.tar.gz",
       "checksum": "4035d0a07c1cfa0e75f56414757ac7c609a801c78cc6df9d1d41927426c325a7",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.freebsd-amd64.tar.gz",
       "checksum": "a8391447ea6c77b67163f7dd9fd3708fd9ba396ae128fd77dac4f8c249c8c223",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.linux-386.tar.gz",
       "checksum": "519b3e6ae4db011b93b60e6fabb055773ae6448355b6909a6befef87e02d98f5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.linux-amd64.tar.gz",
       "checksum": "68a2297eb099d1a76097905a2ce334e3155004ec08cdea85f24527be3c48e856",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.linux-arm64.tar.gz",
       "checksum": "e2a61328101eff3b9c1ba47ecfec5eb2fdc3eb35d8c27d505737ba98bfcb197b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.linux-armv6l.tar.gz",
       "checksum": "931906d67cae1222f501e7be26e0ee73ba89420be0c4591925901cb9a4e156f0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.linux-ppc64le.tar.gz",
       "checksum": "807b036bb058061b6090635e2a8612aaf301895dce70a773bbcd67fa1e57337c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.linux-s390x.tar.gz",
       "checksum": "b7122795910b70b68e4118d0d34685a30925f4dd861c065cf20b699a7783807a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.windows-386.zip",
       "checksum": "c9ad29eff640bf8cb551853c649fd63acd777fcb28db26712d07983a973cb327",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.windows-amd64.zip",
       "checksum": "7d162b83157d3171961f8e05a55b7da8476244df3fac28a5da1c9e215acfea89",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3319,77 +3319,77 @@
   ],
   "1.13.1": [
     {
-      "url": "/dl/go1.13.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.darwin-amd64.tar.gz",
       "checksum": "f3985fced3adecb62dd1e636cfa5eb9fea8f3e98101d9fcc4964d8f1ec255b7f",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.freebsd-386.tar.gz",
       "checksum": "3d3a97cc1c778326df13a9a5460bce14094402edbcfb9f529f507344cfea0bc4",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.freebsd-amd64.tar.gz",
       "checksum": "1ae71f3a02c95cd559f5943aced2f337fb8b58b95db47001ebca48992c7df1d3",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.linux-386.tar.gz",
       "checksum": "4bf7a961fda7ad892b8824002036de8c0f290df05df2e8f11252d1f8c77dcd8f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.linux-amd64.tar.gz",
       "checksum": "94f874037b82ea5353f4061e543681a0e79657f787437974214629af8407d124",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.1.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.linux-arm64.tar.gz",
       "checksum": "8af8787b7c2a3c0eb3f20f872577fcb6c36098bf725c59c4923921443084c807",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.linux-armv6l.tar.gz",
       "checksum": "7c75d4002321ea4a066dfe13f6dd5168076e9a231317c5afd55e78b86f478e37",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.1.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.linux-ppc64le.tar.gz",
       "checksum": "72422c68dbed013ee321a05dbb97d9c8d6b2c75f347de707138c2c748fc4aceb",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.1.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.1.linux-s390x.tar.gz",
       "checksum": "5f0859ae1037ad7af6cdb6d16f638de908fd9de044d463eeab92b9578d4c7c75",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.1.windows-386.zip",
       "checksum": "bc0010efa39d5d46e2d7c7bbb702ca37796d95b395003e22080414076556c590",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.1.windows-amd64.zip",
       "checksum": "24cb08d369c1962cccacedc56fd79dc130f623b3b667a316554621ad6ac9b442",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3398,77 +3398,77 @@
   ],
   "1.13.10": [
     {
-      "url": "/dl/go1.13.10.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.darwin-amd64.tar.gz",
       "checksum": "ce26375c1aee62a7826e02bd0b807a6bb3e32e18492b48648410fa37ab5057c7",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.10.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.freebsd-386.tar.gz",
       "checksum": "c768c2aca1dbacfedaeccf825118abb8ba1dbfff7d1d01988aed806a9ffa9315",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.10.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.freebsd-amd64.tar.gz",
       "checksum": "0b292bfdcc1d278ef46dfed074d21f7620cbc4096ed546cd487264a36fac3a03",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.10.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.linux-386.tar.gz",
       "checksum": "233c9d43fe2fab27ee489efea08b84665aec5855cce95a81dba3846636de5fed",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.10.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.linux-amd64.tar.gz",
       "checksum": "8a4cbc9f2b95d114c38f6cbe94a45372d48c604b707db2057c787398dfbf8e7f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.10.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.linux-arm64.tar.gz",
       "checksum": "f16f19947855b410e48f395ca488bd39223c7b35e8b69c7f15ec00201e20b572",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.10.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.linux-armv6l.tar.gz",
       "checksum": "3c581f11ed49eaf0954f62ffebc123f8c392fc536f01c5a44cb38185701101fc",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.10.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.linux-ppc64le.tar.gz",
       "checksum": "6b9505388ecafa3cb04d5f51638276b25f7d80c5f70bd74ed72f8013f5006fd9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.10.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.10.linux-s390x.tar.gz",
       "checksum": "41cb67266e809920363ff620e8cabce152ab54bebd6a337e9f903f5c1996ec35",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.10.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.10.windows-386.zip",
       "checksum": "c04d2d86826f06b35ae88ae077bfe9027e74adc25516caf8ddb7cf5e7b497736",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.10.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.10.windows-amd64.zip",
       "checksum": "e56ff68ab0d0ebdd9d11e9f3ef4b47fb7bd3a379cb07d444b9f7d77c7009088a",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3477,77 +3477,77 @@
   ],
   "1.13.11": [
     {
-      "url": "/dl/go1.13.11.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.darwin-amd64.tar.gz",
       "checksum": "37f748b464f823eb91922013eb64f263961724c30ebddb47c39d485ae08e9874",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.11.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.freebsd-386.tar.gz",
       "checksum": "99e707170751b19ec70fa9ab1d13d78c9df9ac804e5ed50ed6e9387b45b9eb16",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.11.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.freebsd-amd64.tar.gz",
       "checksum": "12a855728f26266dc8a1a77f524197ba16455315e879ae9dcab904391f679cdb",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.11.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.linux-386.tar.gz",
       "checksum": "c61ea511a4e82e9a7d31684d33c7b8bbb275e4110490f9a320c8026b76cac4ee",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.11.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.linux-amd64.tar.gz",
       "checksum": "a4d71ca9e02923fa96669a4b5faf78ee8331b18e7209b09dd87fe763b4838ada",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.11.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.linux-arm64.tar.gz",
       "checksum": "6c81c0ce79be2bd3ac5ea69c709ea9bd588069632ded4ac39d58dadf4d2f93e6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.11.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.linux-armv6l.tar.gz",
       "checksum": "f762f3acdaf2bb8d32041110022104aa430d96c39a8fc9cf3d4ab74faa607fca",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.11.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.linux-ppc64le.tar.gz",
       "checksum": "d9697e5bcf3a3ac0ba1ff299bb72ffd4957b9893a19a1e65adce683144d795e3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.11.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.11.linux-s390x.tar.gz",
       "checksum": "076f31fb29aa5129151aaf850593b16b4391157870a15a3f0199554a99db0b9b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.11.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.11.windows-386.zip",
       "checksum": "d36e85f6a99a9955b5b348dc13378f2bf15eb32bbc691f0e582fc5c3a09d71ed",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.11.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.11.windows-amd64.zip",
       "checksum": "e6d1805cc70d042133b94a598c7e666b166ee804d541ec35e63ca8eb3053036b",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3556,77 +3556,77 @@
   ],
   "1.13.12": [
     {
-      "url": "/dl/go1.13.12.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.darwin-amd64.tar.gz",
       "checksum": "beaab00ed7c60594201b47a0228b058c2c23a93b9d7a45697591e10273970049",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.12.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.linux-386.tar.gz",
       "checksum": "625d9cdb25ba55e1afba9490c79c55767117fa272e067f81643d22268d51308a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.12.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.linux-amd64.tar.gz",
       "checksum": "9cacc6653563771b458c13056265aa0c21b8a23ca9408278484e4efde4160618",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.12.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.linux-arm64.tar.gz",
       "checksum": "7a8b4e7841d978c95dae8ef53e19811ee2d5c595a1c5ec7afed74bb8f71588b8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.12.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.linux-armv6l.tar.gz",
       "checksum": "552db731a120d341a1756c6ce0b1029cb5f5c756c09de9f45273893268d19c23",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.12.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.12.windows-386.zip",
       "checksum": "8d45cae6d2138b6ad470cee8b78b4739a1d02cdd976a9c9861f067a102e9affe",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.12.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.12.windows-amd64.zip",
       "checksum": "43c4b434f965efa9015c47a1f65858f62ab425fba9fa36a48ed40d1805dd0479",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.12.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.freebsd-386.tar.gz",
       "checksum": "b67385a062206630b85a9efe0abcbd0afc399ff79182d06aae2a3677ccc9dbcb",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.12.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.freebsd-amd64.tar.gz",
       "checksum": "875e9e264aceb97275637366b05d27ed24afa05cf3af9b5b0a248c76ba73ba02",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.12.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.linux-ppc64le.tar.gz",
       "checksum": "97d762a62eae2e1f4d89ce09a89407a63e12c22d5c0fb952e409b323927cd38e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.12.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.12.linux-s390x.tar.gz",
       "checksum": "8dd2d50666176cbe5cab7557081acb0f380cef2240e18d05db7faffc03d8f356",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
@@ -3635,77 +3635,77 @@
   ],
   "1.13.2": [
     {
-      "url": "/dl/go1.13.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.darwin-amd64.tar.gz",
       "checksum": "fdf29cc185ece8b038b41b469c2c6095891059b4acad94042e4a777f2f0a1116",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.freebsd-386.tar.gz",
       "checksum": "687206009c7643d8657c7b15573e1a399e15fecef301184fb8684a11ae885e3e",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.freebsd-amd64.tar.gz",
       "checksum": "71f163fdf4a2a0d82a951f07237978f852def373294daa481d487d15e0c5cb76",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.linux-386.tar.gz",
       "checksum": "468f116889631405da0c89b1765985e8bbeddbf8642c2a552a81f0bfbe58ab55",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.linux-amd64.tar.gz",
       "checksum": "293b41a6ccd735eebcfb4094b6931bfd187595555cecf3e4386e9e119220c0b7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.2.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.linux-arm64.tar.gz",
       "checksum": "a2d27f341d6b7968f9da229990aa9ab7a6d4bd1c722945be11576a09eb538482",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.2.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.linux-armv6l.tar.gz",
       "checksum": "6f2e90b5d08a177be14938a905f7b91e9b17052318b5ea0e6d7c0a83af252421",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.2.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.linux-ppc64le.tar.gz",
       "checksum": "ffcc3651fce34fc6418e33836d5417c0e6b713fda99033259e67538fa802900a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.2.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.2.linux-s390x.tar.gz",
       "checksum": "dbed59db3e4f57df7c86120be37bdbf3516891214174b771cff40d81ba8577e2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.2.windows-386.zip",
       "checksum": "c0c5ac83e354b76f78532ed83590151648dfd52d58dd832ecaee9ea0daa07c42",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.2.windows-amd64.zip",
       "checksum": "003c99e778d6f73ba677fec4b66c3bdbbb144b318cfe6ffbe26ed8493b2db9a5",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3714,77 +3714,77 @@
   ],
   "1.13.3": [
     {
-      "url": "/dl/go1.13.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.darwin-amd64.tar.gz",
       "checksum": "dde04dec8730d72e4d350a4e1b123a3f94aa15e7f34ed8163e72c948916c48ae",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.freebsd-386.tar.gz",
       "checksum": "1a79e9013a4421b5e99c0bed81b97460a012d22513a0efedc6107add43e579e7",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.freebsd-amd64.tar.gz",
       "checksum": "d5337c217ae111ade704a4c3ca618921d4d7ef6d52236a137e70e691e4188c02",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.linux-386.tar.gz",
       "checksum": "c68ebb127924ee753d05fcd4cc893e3409a6754e8884bb04e5248e9b5849f6ba",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.linux-amd64.tar.gz",
       "checksum": "0804bf02020dceaa8a7d7275ee79f7a142f1996bfd0c39216ccb405f93f994c0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.3.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.linux-arm64.tar.gz",
       "checksum": "9fa65ae42665baff53802091b49b83af6f2e397986b6cbea2ae30e2c7ee0f2f2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.linux-armv6l.tar.gz",
       "checksum": "9f15d6aa4098cd53ec5cb48d1a1e554d062b2263a03985d50c2568757d966dc6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.3.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.linux-ppc64le.tar.gz",
       "checksum": "2373b60d7f7b4825b1d0ec195079833a3dac72ddd55b207ee22b0032b1a658d9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.3.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.3.linux-s390x.tar.gz",
       "checksum": "9241ce5bf362b7066c90da5abc4c85ec7b4054637e1a8a01b8cc83281e228b7e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.3.windows-386.zip",
       "checksum": "b27a4266652f1a72b4023bccd1b036ba356cc6a27c18d329a8e624759626298d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.3.windows-amd64.zip",
       "checksum": "9585efeab37783152c81c6ce373b22e68f45c6801dc2c208bfd1e47b646efbef",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3793,77 +3793,77 @@
   ],
   "1.13.4": [
     {
-      "url": "/dl/go1.13.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.darwin-amd64.tar.gz",
       "checksum": "a9088c44a984c4ba64179619606cc65d9d0cb92988012cfc94fbb29ca09edac7",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.freebsd-386.tar.gz",
       "checksum": "ecb75927a71e232ef849c4f75388e2132c04bc429b0e2501d7bac5598fbd34f2",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.freebsd-amd64.tar.gz",
       "checksum": "2eeb50a31c61a8ce468ab7c350e6b6c43d8e9572c796742c8b3da8422c46e470",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.linux-386.tar.gz",
       "checksum": "497934398ca57c7c207ce3388f099823923b4c7b74394d6ed64cd2d3751aecb8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.linux-amd64.tar.gz",
       "checksum": "692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.4.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.linux-arm64.tar.gz",
       "checksum": "8b8d99eb07206f082468fb4d0ec962a819ae45d54065fc1ed6e2c502e774aaf0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.linux-armv6l.tar.gz",
       "checksum": "9f76e6353c9ae2dcad1731b7239531eb8be2fe171f29f2a9c5040945a930fd41",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.linux-ppc64le.tar.gz",
       "checksum": "815bf3c7100e73cfac50c4a07c8eeb4b0458a49ffa0e13a74a6cf7ad8e2a6499",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.4.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.4.linux-s390x.tar.gz",
       "checksum": "efc6947e8eb0a6409f4c8ba62b00ae4e54404064bc221df1b73364a95945a350",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.4.windows-386.zip",
       "checksum": "a6956184e31b5c97ee76ed736f1c5b708ace7f5673511862f9fcb8ab64851286",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.4.windows-amd64.zip",
       "checksum": "ab8b7f7a2a4f7b58720fb2128b32c7471092961ff46a01d9384fb489d8212a0b",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3872,77 +3872,77 @@
   ],
   "1.13.5": [
     {
-      "url": "/dl/go1.13.5.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.darwin-amd64.tar.gz",
       "checksum": "97f9ec90d54f3a580789f1f855b17282e7dbccb69a44b20a20c2167e907db800",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.5.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.freebsd-386.tar.gz",
       "checksum": "005b45ed277374d50acef5daa889139ed4e8fdd34c7e5c6e134d846cbe12c7f2",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.5.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.freebsd-amd64.tar.gz",
       "checksum": "9da24f876f321c1485d46f597546d72c3d38a5d8eade45724fdc40cc19fc042a",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.5.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.linux-386.tar.gz",
       "checksum": "3b830fa25f79ab08b476f02c84ea4125f41296b074017b492ac1ff748cf1c7c9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.5.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.linux-amd64.tar.gz",
       "checksum": "512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.5.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.linux-arm64.tar.gz",
       "checksum": "227b718923e20c846460bbecddde9cb86bad73acc5fb6f8e1a96b81b5c84668b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.5.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.linux-armv6l.tar.gz",
       "checksum": "26259f61d52ee2297b1e8feef3a0fc82144b666a2b95512402c31cc49713c133",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.5.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.linux-ppc64le.tar.gz",
       "checksum": "292814a5ea42a6fc43e1d1ea61c01334e53959e7ab34de86eb5f6efa9742afb6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.5.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.5.linux-s390x.tar.gz",
       "checksum": "cfbb2959f243880abd1e2efd85d798b8d7ae4a502ab87c4b722c1bd3541e5dc3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.5.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.5.windows-386.zip",
       "checksum": "5a9ace58c0fb487a07a3dec494a59957aa8425fbefd04d1a3fb1d0aa0d95fb8d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.5.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.5.windows-amd64.zip",
       "checksum": "027275e04d795fbadc898ba7a50ed0ab2161ff4c5e613c94dbb066b2ca24ec11",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -3951,77 +3951,77 @@
   ],
   "1.13.6": [
     {
-      "url": "/dl/go1.13.6.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.darwin-amd64.tar.gz",
       "checksum": "1ee0dc6a7abf389dac898cbe27e28c4388a61e45cba2632c01d749e25003007f",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.6.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.freebsd-386.tar.gz",
       "checksum": "e02727feb4680cd643f9b8f5e953196675d0b9d4129dba1d5fbd98db01c24643",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.6.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.freebsd-amd64.tar.gz",
       "checksum": "c8153d236558aa878b7bc844ebede38f09ac846bee037f0f57a8dd75e36d8056",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.6.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.linux-386.tar.gz",
       "checksum": "27feb013106da784f09e560720aa41ab395c67f7eed4c4a0fce04bc6e3d01c7d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.6.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.linux-amd64.tar.gz",
       "checksum": "a1bc06deb070155c4f67c579f896a45eeda5a8fa54f35ba233304074c4abbbbd",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.6.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.linux-arm64.tar.gz",
       "checksum": "0a18125c4ed80f9c3045cf92384670907c4796b43ed63c4307210fe93e5bbca5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.6.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.linux-armv6l.tar.gz",
       "checksum": "37a1a83e363dcf146a67fa839d170fd1afb13009585fdd493d0a3370fbe6f785",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.6.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.linux-ppc64le.tar.gz",
       "checksum": "26a977a8af5dc50a562f0a57b58dded5fa3bacfe77722cf8a84ea54ca54728dd",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.6.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.6.linux-s390x.tar.gz",
       "checksum": "5cd9900a1fa0f0cac657930b648381cad9b8c5e2bbc77caf86a6fb5cedad0017",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.6.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.6.windows-386.zip",
       "checksum": "6b1595d3b5b5fbdbaf6031502d90a694d1e7ae297433fc01c6c48fe8bc987495",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.6.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.6.windows-amd64.zip",
       "checksum": "66eae07e03310b67d279701028ba8dc6948cd0acdc6fbe21c22bfa9a2bc48884",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -4030,77 +4030,77 @@
   ],
   "1.13.7": [
     {
-      "url": "/dl/go1.13.7.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.darwin-amd64.tar.gz",
       "checksum": "8436f846b49c2b14a96d90eef6b2a6e0a0e1943bbb767299c1ecabb795b042b9",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.7.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.freebsd-386.tar.gz",
       "checksum": "b205d3657ca050b0c69d1fe4a76a2f66aa879f5ef87cc2814241610906e19924",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.7.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.freebsd-amd64.tar.gz",
       "checksum": "6952d9746ba04ea86341690dc93763f6b68319f7bec2b11d7028e1cffa408bdb",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.7.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.linux-386.tar.gz",
       "checksum": "93e82683f32d9fe7fda9b686415aeee599a92c4e450b69519bb53e1d62144a85",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.7.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.linux-amd64.tar.gz",
       "checksum": "b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.7.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.linux-arm64.tar.gz",
       "checksum": "8717de6c662ada01b7bf318f5025c046b57f8c10cd39a88268bdc171cc7e4eab",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.7.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.linux-armv6l.tar.gz",
       "checksum": "ff8b870222d82c38a0108810706811dcbd1fcdbddc877789184a0f903cbdf11a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.7.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.linux-ppc64le.tar.gz",
       "checksum": "8fe0aeb41e87fd901845c9598f17f1aae90dca25d2d2744e9664c173fbf7f784",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.7.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.7.linux-s390x.tar.gz",
       "checksum": "7d405e515029d19131bae2820310681c31b665178998335ecc4494e8de01dfeb",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.7.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.7.windows-386.zip",
       "checksum": "cf9b1a2f96240adb98dc4081121ac308bf6f8d2760f96d45f429ec571602cefc",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.7.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.7.windows-amd64.zip",
       "checksum": "03befd335ee9ddf1d10cae52e84eb5a37408b8e105acc1c29e30bbbbd8143749",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -4109,77 +4109,77 @@
   ],
   "1.13.8": [
     {
-      "url": "/dl/go1.13.8.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.darwin-amd64.tar.gz",
       "checksum": "e7bad54950e1d18c716ac9202b5406e7d4aca9aa4ca9e334a9742f75c2167a9c",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.8.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.freebsd-386.tar.gz",
       "checksum": "5e02b9d3a3b5d7c61d43eea80b27875a9350472ffcb80c08fad857076d670d8b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.8.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.freebsd-amd64.tar.gz",
       "checksum": "d8ea8fa5f93ba66f1f011fe40706635a95d754704da68ec7c406ba52ed4ec93a",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.8.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.linux-386.tar.gz",
       "checksum": "2305c1c46b3eaf574c7b03cfa6b167c199a2b52da85872317438c90074fdb46e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.8.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.linux-amd64.tar.gz",
       "checksum": "0567734d558aef19112f2b2873caa0c600f1b4a5827930eb5a7f35235219e9d8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.8.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.linux-arm64.tar.gz",
       "checksum": "b46c0235054d0eb69a295a2634aec8a11c7ae19b3dc53556a626b89dc1f8cdb0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.8.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.linux-armv6l.tar.gz",
       "checksum": "75f590d8e048a97cbf8b09837b15b3e6b44e1374718a96a5c3a994843ef44a4d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.8.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.linux-ppc64le.tar.gz",
       "checksum": "4c987b3969d33a93880a218064d2330d7f55c9b58698e78db6b56012058e91a9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.8.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.8.linux-s390x.tar.gz",
       "checksum": "994f961df0d7bdbfa6f7eed604539acf9159444dabdff3ce8e938d095d85f756",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.8.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.8.windows-386.zip",
       "checksum": "00c765048392c78fd3681ea5279c408e21fc94f033a504a1158fc6279fb068e3",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.8.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.8.windows-amd64.zip",
       "checksum": "aaf0888907144ca7070c8dad03fcf1308f77a42d2f6e4d2a609e64e9ae73cf4f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -4188,77 +4188,77 @@
   ],
   "1.13.9": [
     {
-      "url": "/dl/go1.13.9.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.darwin-amd64.tar.gz",
       "checksum": "450e59538ed5d3f2b165ba5107530afce6e8e89c6cc5c90a0cbf0a58846ef3b1",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.9.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.freebsd-386.tar.gz",
       "checksum": "6b75a5a46ebbdf06aa5023f2bd0ad7e9e37389125468243368d5795e1c15c9cd",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.9.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.freebsd-amd64.tar.gz",
       "checksum": "87716246da52c193226df44031aaf45e45ebfc23e01bdc845311c1b560e76e2b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.9.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.linux-386.tar.gz",
       "checksum": "a2744aa2ddc68d888e9f65c2cbe4c8b527b139688ce232ead90dc2961f8d51a8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.9.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.linux-amd64.tar.gz",
       "checksum": "f4ad8180dd0aaf7d7cda7e2b0a2bf27e84131320896d376549a7d849ecf237d7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.13.9.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.linux-arm64.tar.gz",
       "checksum": "b53cb466d7986e5e17a3d4c196bc95df08a35968eced5efd7e128387a246c46e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.13.9.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.linux-armv6l.tar.gz",
       "checksum": "a3c2941a1fde8692514ece7e2180a0e3ca70609f52756a66bc0ab68c63572361",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.13.9.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.linux-ppc64le.tar.gz",
       "checksum": "90beb01962202f332be0a7c8dad2db3d30242759ba863db3f36c45d241940efc",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.13.9.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.13.9.linux-s390x.tar.gz",
       "checksum": "a40949aaf55912b06df8fda511c33fde3e52d377706bdc095332652c1ad225e3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.13.9.windows-386.zip",
+      "url": "https://golang.org/dl/go1.13.9.windows-386.zip",
       "checksum": "e22406377448f1aea2dd1517327e5ae452d826c0c7624b3511d5af510c57b69a",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.13.9.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.13.9.windows-amd64.zip",
       "checksum": "cf066aabdf4d83c251aaace14b57a35aafffd1fa67d54d907f27fb31e470a135",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -4267,77 +4267,77 @@
   ],
   "1.14": [
     {
-      "url": "/dl/go1.14.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.darwin-amd64.tar.gz",
       "checksum": "2472dcd681b761501fadb35ec361503efd27de2ba2270b2fe35cb6ece7362243",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.freebsd-386.tar.gz",
       "checksum": "9717901860aab759ff1e555b0e62d58669939f7b2a86fc45d4015db29c92614d",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.freebsd-amd64.tar.gz",
       "checksum": "d86041687515ac3729807cdaa6787a1a10ee4cfdefd427043dcdb20544096fa1",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.linux-386.tar.gz",
       "checksum": "cdcdab6c8d1f2dcea3bbec793352ef84db167a2eb6c60ff69e5cf94dca575f9a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.linux-amd64.tar.gz",
       "checksum": "08df79b46b0adf498ea9f320a0f23d6ec59e9003660b4c9c1ce8e5e2c6f823ca",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.linux-arm64.tar.gz",
       "checksum": "cd813387f770c07819912f8ff4b9796a4e317dee92548b7226a19e60ac79eb27",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.14.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.14.linux-armv6l.tar.gz",
       "checksum": "b5e682176d7ad3944404619a39b585453a740a2f82683e789f4279ec285b7ecd",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.14.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.14.linux-ppc64le.tar.gz",
       "checksum": "b896b5eba616d27fd3bb8218de6bef557cb62221e42f73c84ae4b89cdb602dec",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.14.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.14.linux-s390x.tar.gz",
       "checksum": "22e67470fe872c893face196f02323a11ffe89999260c136b9c50f06619e0243",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.14.windows-386.zip",
+      "url": "https://golang.org/dl/go1.14.windows-386.zip",
       "checksum": "adb634bedc4143b67c50b2e60f36a2cbcad6ab05ec41a972e2115701584170a2",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.14.windows-amd64.zip",
       "checksum": "cc2f1e8d19744fe0b2e979bf9a4f9d224e416f4f54cb6cf3aa8b5e9c0865de37",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -4346,77 +4346,77 @@
   ],
   "1.14.1": [
     {
-      "url": "/dl/go1.14.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.darwin-amd64.tar.gz",
       "checksum": "6632f9d53fd95632e431e8c34295349cca3f0a124e3a28b760ae5c42b32816e3",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.freebsd-386.tar.gz",
       "checksum": "1c52e3b72d1802a516709f7908007987c3ec902d847708539eb1acfee810ec7a",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.freebsd-amd64.tar.gz",
       "checksum": "7d840ba12c6aade31b0e24c59a824a35a40a48686087e6423fa526f048328246",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.linux-386.tar.gz",
       "checksum": "92d465accdebbe2d0749b2f90c22ecb1fd2492435144923f88ce410cd56b6546",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.linux-amd64.tar.gz",
       "checksum": "2f49eb17ce8b48c680cdb166ffd7389702c0dec6effa090c324804a5cac8a7f8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.1.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.linux-arm64.tar.gz",
       "checksum": "5d8f2c202f35481617e24e63cca30c6afb1ec2585006c4a6ecf16c5f4928ab3c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.14.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.linux-armv6l.tar.gz",
       "checksum": "04f10e345dae0d7c6c32ffd6356b47f2d4d0e8a0cb757f4ef48ead6c5bef206f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.14.1.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.linux-ppc64le.tar.gz",
       "checksum": "6559201d452ee2782dfd684d59c05e3ecf789dc40a7ec0ad9ae2dd9f489c0fe1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.14.1.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.14.1.linux-s390x.tar.gz",
       "checksum": "af009bd6e7729c441fec78af427743fefbf11f919c562e01b37836d835f74226",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.14.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.14.1.windows-386.zip",
       "checksum": "66a6dcf28298ce2c3311487af0822adfec789e07bebc3b5cc6a75be9fadaef24",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.14.1.windows-amd64.zip",
       "checksum": "4bcc3bbdeba4b298120b4ea78e22b8c0fe93478b47dd7b84d70d97d2b264a0a6",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -4425,77 +4425,77 @@
   ],
   "1.14.2": [
     {
-      "url": "/dl/go1.14.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.darwin-amd64.tar.gz",
       "checksum": "e0db81f890bb253552b3fd783fccbc2cdda02552295cb305e75984eef1c1e2b9",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.freebsd-386.tar.gz",
       "checksum": "7b8eccc27bf0a6a57999c1d30447ab61be19509a244ac3617bc4d1797eecb555",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.freebsd-amd64.tar.gz",
       "checksum": "b9a26f5e2443898b54d7778d6861df70e8342d33a74bd7e02cf1105c4144ec05",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.linux-386.tar.gz",
       "checksum": "cab5f51e6ffb616c6ee963c3d0650ca4e3c4108307c44f2baf233fcb8ff098f6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.linux-amd64.tar.gz",
       "checksum": "6272d6e940ecb71ea5636ddb5fab3933e087c1356173c61f4a803895e947ebb3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.2.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.linux-arm64.tar.gz",
       "checksum": "bb6d22fe5806352c3d0826676654e09b6e41eb1af52e8d506d3fa85adf7f8d88",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.14.2.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.linux-armv6l.tar.gz",
       "checksum": "eb4550ba741506c2a4057ea4d3a5ad7ed5a887de67c7232f1e4795464361c83c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.14.2.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.linux-ppc64le.tar.gz",
       "checksum": "48c22268c81ced9084a43bbe2c1596d3e636b5560b30a32434a7f15e561de160",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.14.2.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.14.2.linux-s390x.tar.gz",
       "checksum": "501cc919648c9d85b901963303c5061ea6814c80f0d35fda9e62980d3ff58cf4",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.14.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.14.2.windows-386.zip",
       "checksum": "76beccad98b6d3f8de935e5c9dbd69934cca1baa45b880965cdcf2779df56524",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.14.2.windows-amd64.zip",
       "checksum": "1b5a60b3bbaa81106d5ee03499b5734ec093c6a255abf9a6a067f0f497a57916",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -4504,77 +4504,77 @@
   ],
   "1.14.3": [
     {
-      "url": "/dl/go1.14.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.darwin-amd64.tar.gz",
       "checksum": "a8b43d9f65c2768ac2e377793383630a9be2c8c71b643c9a9520855a0d2af41c",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.freebsd-386.tar.gz",
       "checksum": "7c5adb1a481d899b782d633541affe17f0d5ebdd97e32bfc01f274603555e14d",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.freebsd-amd64.tar.gz",
       "checksum": "86da72a7da23c10af39fcc191ab15ad42e77c13ea7bd41c7ea3460f1f502bbe6",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.linux-386.tar.gz",
       "checksum": "46f8c744788103e8aeceb12c7d71eb16a58fe43e7e4711055fa9ef4bae50bff7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.linux-amd64.tar.gz",
       "checksum": "1c39eac4ae95781b066c144c58e45d6859652247f7515f0d2cba7be7d57d2226",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.3.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.linux-arm64.tar.gz",
       "checksum": "a7a593e2ee079d83a1943edcd1c9ed2dae7529666fce04de8c142fb61c7cdd3e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.14.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.linux-armv6l.tar.gz",
       "checksum": "b1c3a648c3c8877b98dfba1996dec604c8fb8899db07994b2dfd47b0063367c8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.14.3.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.linux-ppc64le.tar.gz",
       "checksum": "329359e2b72839696e78b6c0a96fd939e28e7435d852f31107f68037dd5f7442",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.14.3.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.14.3.linux-s390x.tar.gz",
       "checksum": "1aad312fc7fa85d663e8226237cc7519b2599b88a213098abc10de8e84d6cfab",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.14.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.14.3.windows-386.zip",
       "checksum": "b0007593f4e293980d968acc97162692e04cec12b07b5a4928dba64462574abd",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.14.3.windows-amd64.zip",
       "checksum": "6811c14341fa0e5ebe05b28a4a8086e51a25ee54bc860f83183e1c478e3b1b60",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -4583,77 +4583,77 @@
   ],
   "1.14.4": [
     {
-      "url": "/dl/go1.14.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.darwin-amd64.tar.gz",
       "checksum": "3fa7ed8dc44fdd50c0bfe72676250cceca527d59950aef20af906a670cf88de2",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.linux-386.tar.gz",
       "checksum": "4179f406ea0efd455a8071eaaaf1dea92cac5c17aab89fbad18ea2a37623c810",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.linux-amd64.tar.gz",
       "checksum": "aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.4.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.linux-arm64.tar.gz",
       "checksum": "05dc46ada4e23a1f58e72349f7c366aae2e9c7a7f1e7653095538bc5bba5e077",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.14.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.linux-armv6l.tar.gz",
       "checksum": "e20211425b3f797ca6cd5e9a99ab6d5eaf1b009d08d19fc8a7835544fa58c703",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.14.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.14.4.windows-386.zip",
       "checksum": "555d7e9919ca58d5c64b2377ca09095eeba3a5d19766f2581ff02e9eb004f6fc",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.14.4.windows-amd64.zip",
       "checksum": "e04f591219b18e7cabe73eb79c90405b5c7a5baee61377670d7a48429c5c978d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.freebsd-386.tar.gz",
       "checksum": "3fa0ab73cddf4117010285a00df5c7c0b0c8617a3b8aa4e3876197e433986897",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.14.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.freebsd-amd64.tar.gz",
       "checksum": "73da292c1b5980f5e3d6506d6d9ef65a67533936f8e0cb775d726fe3a715e519",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.14.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.linux-ppc64le.tar.gz",
       "checksum": "b335f85bc935ca3f553ad1bac37da311aaec887ffd8a48cb58a0abb0d8adf324",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.14.4.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.14.4.linux-s390x.tar.gz",
       "checksum": "17f2ae0bae968b3d909daabc5cc4a37471ddb70ec49076b78702291e6772d71a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
@@ -4662,70 +4662,70 @@
   ],
   "1.2.2": [
     {
-      "url": "/dl/go1.2.2.darwin-386-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.2.2.darwin-386-osx10.6.tar.gz",
       "checksum": "360ec6cbfdec9257de029f918a881b9944718d7c",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.2.2.darwin-386-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.2.2.darwin-386-osx10.8.tar.gz",
       "checksum": "4219b464e82e7c23d9dc02c193e7a0a28a09af1a",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.2.2.darwin-amd64-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.2.2.darwin-amd64-osx10.6.tar.gz",
       "checksum": "24c182718fd61b2621692dcdfc34937a6b5ee369",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.2.2.darwin-amd64-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.2.2.darwin-amd64-osx10.8.tar.gz",
       "checksum": "19be1eca8fc01b32bb6588a70773b84cdce6bed1",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.2.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.2.2.freebsd-386.tar.gz",
       "checksum": "d226b8e1c3f75d31fa426df63aa776d7e08cddac",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.2.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.2.2.freebsd-amd64.tar.gz",
       "checksum": "858744ab8ff9661d42940486af63d451853914a0",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.2.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.2.2.linux-386.tar.gz",
       "checksum": "d16f892173b0589945d141cefb22adce57e3be9c",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.2.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.2.2.linux-amd64.tar.gz",
       "checksum": "6bd151ca49c435462c8bf019477a6244b958ebb5",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.2.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.2.2.windows-386.zip",
       "checksum": "560bb33ec70ab733f31ff15f1a48fe35963983b9",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.2.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.2.2.windows-amd64.zip",
       "checksum": "9ee22fe6c4d98124d582046aab465ab69eaab048",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -4734,70 +4734,70 @@
   ],
   "1.3": [
     {
-      "url": "/dl/go1.3.darwin-386-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.3.darwin-386-osx10.6.tar.gz",
       "checksum": "159d2797bee603a80b829c4404c1fb2ee089cc00",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.3.darwin-386-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.3.darwin-386-osx10.8.tar.gz",
       "checksum": "bade975462b5610781f6a9fe8ac13031b3fb7aa6",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.3.darwin-amd64-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.3.darwin-amd64-osx10.6.tar.gz",
       "checksum": "82ffcfb7962ca7114a1ee0a96cac51c53061ea05",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.3.darwin-amd64-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.3.darwin-amd64-osx10.8.tar.gz",
       "checksum": "8d768f10cd00e0b152490291d9cd6179a8ccf0a7",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.3.freebsd-386.tar.gz",
       "checksum": "8afa9574140cdd5fc97883a06a11af766e7f0203",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.3.freebsd-amd64.tar.gz",
       "checksum": "71214bafabe2b5f52ee68afce96110031b446f0c",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.3.linux-386.tar.gz",
       "checksum": "22db33b0c4e242ed18a77b03a60582f8014fd8a6",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.3.linux-amd64.tar.gz",
       "checksum": "b6b154933039987056ac307e20c25fa508a06ba6",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.3.windows-386.zip",
       "checksum": "e4e5279ce7d8cafdf210a522a70677d5b9c7589d",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.3.windows-amd64.zip",
       "checksum": "1e4888e1494aed7f6934acb5c4a1ffb0e9a022b1",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -4806,70 +4806,70 @@
   ],
   "1.3.1": [
     {
-      "url": "/dl/go1.3.1.darwin-386-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.3.1.darwin-386-osx10.6.tar.gz",
       "checksum": "84f70a4c83be24cea696654a5b55331ea32f8a3f",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.3.1.darwin-386-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.3.1.darwin-386-osx10.8.tar.gz",
       "checksum": "244dfba1f4239b8e2eb9c3abae5ad63fc32c807a",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.3.1.darwin-amd64-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.3.1.darwin-amd64-osx10.6.tar.gz",
       "checksum": "40716361d352c4b40252e79048e8bc084c3f3d1b",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.3.1.darwin-amd64-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.3.1.darwin-amd64-osx10.8.tar.gz",
       "checksum": "a7271cbdc25173d0f8da66549258ff65cca4bf06",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.3.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.3.1.freebsd-386.tar.gz",
       "checksum": "586debe95542b3b56841f6bd2e5257e301a1ffdc",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.3.1.freebsd-amd64.tar.gz",
       "checksum": "99e23fdd33860d837912e8647ed2a4b3d2b09d3c",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.3.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.3.1.linux-386.tar.gz",
       "checksum": "36f87ce21cdb4cb8920bb706003d8655b4e1fc81",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.3.1.linux-amd64.tar.gz",
       "checksum": "3af011cc19b21c7180f2604fd85fbc4ddde97143",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.3.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.3.1.windows-386.zip",
       "checksum": "64f99e40e79e93a622e73d7d55a5b8340f07747f",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.3.1.windows-amd64.zip",
       "checksum": "4548785cfa3bc228d18d2d06e39f58f0e4e014f1",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -4878,70 +4878,70 @@
   ],
   "1.3.2": [
     {
-      "url": "/dl/go1.3.2.darwin-386-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.3.2.darwin-386-osx10.6.tar.gz",
       "checksum": "d1652f6e0ed3063b7b43d2bc12981d927bc85deb",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.3.2.darwin-386-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.3.2.darwin-386-osx10.8.tar.gz",
       "checksum": "d040c85698c749fdbe25e8568c4d71648a5e3a75",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.3.2.darwin-amd64-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.3.2.darwin-amd64-osx10.6.tar.gz",
       "checksum": "36ca7e8ac9af12e70b1e01182c7ffc732ff3b876",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.3.2.darwin-amd64-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.3.2.darwin-amd64-osx10.8.tar.gz",
       "checksum": "323bf8088614d58fee2b4d2cb07d837063d7d77e",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.3.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.3.2.freebsd-386.tar.gz",
       "checksum": "fea3ef264120b5c3b4c50a8929d56f47a8366503",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.3.2.freebsd-amd64.tar.gz",
       "checksum": "95b633f45156fbbe79076638f854e76b9cd01301",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.3.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.3.2.linux-386.tar.gz",
       "checksum": "3cbfd62d401a6ca70779856fa8ad8c4d6c35c8cc",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.3.2.linux-amd64.tar.gz",
       "checksum": "0e4b6120eee6d45e2e4374dac4fe7607df4cbe42",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.3.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.3.2.windows-386.zip",
       "checksum": "86160c478436253f51241ac1905577d337577ce0",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.3.2.windows-amd64.zip",
       "checksum": "7f7147484b1bc9e52cf034de816146977d0137f6",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -4950,70 +4950,70 @@
   ],
   "1.3.3": [
     {
-      "url": "/dl/go1.3.3.darwin-386-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.3.3.darwin-386-osx10.6.tar.gz",
       "checksum": "04b3e38549183e984f509c07ad40d8bcd577a702",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.3.3.darwin-386-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.3.3.darwin-386-osx10.8.tar.gz",
       "checksum": "88f35d3327a84107aac4f2f24cb0883e5fdbe0e5",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.3.3.darwin-amd64-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.3.3.darwin-amd64-osx10.6.tar.gz",
       "checksum": "dfe68de684f6e8d9c371d01e6d6a522efe3b8942",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.3.3.darwin-amd64-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.3.3.darwin-amd64-osx10.8.tar.gz",
       "checksum": "be686ec7ba68d588735cc2094ccab8bdd651de9e",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.3.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.3.3.freebsd-386.tar.gz",
       "checksum": "875a5515dd7d3e5826c7c003bb2450f3129ccbad",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.3.3.freebsd-amd64.tar.gz",
       "checksum": "8531ae5e745c887f8dad1a3f00ca873cfcace56e",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.3.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.3.3.linux-386.tar.gz",
       "checksum": "9eb426d5505de55729e2656c03d85722795dd85e",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.3.3.linux-amd64.tar.gz",
       "checksum": "14068fbe349db34b838853a7878621bbd2b24646",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.3.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.3.3.windows-386.zip",
       "checksum": "ba99083b22e0b22b560bb2d28b9b99b405d01b6b",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.3.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.3.3.windows-amd64.zip",
       "checksum": "5f0b3b104d3db09edd32ef1d086ba20bafe01ada",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -5022,70 +5022,70 @@
   ],
   "1.4": [
     {
-      "url": "/dl/go1.4.darwin-386-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.4.darwin-386-osx10.6.tar.gz",
       "checksum": "ee31cd0e26245d0e48f11667e4298e2e7f54f9b6",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.4.darwin-386-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.4.darwin-386-osx10.8.tar.gz",
       "checksum": "4d2ae2f5c0216c44e432c6044b1e1f0aea99f712",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.4.darwin-amd64-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.4.darwin-amd64-osx10.6.tar.gz",
       "checksum": "09621b9226abe12c2179778b015a33c1787b29d6",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.4.darwin-amd64-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.4.darwin-amd64-osx10.8.tar.gz",
       "checksum": "28b2b731f86ada85246969e8ffc77d50542cdcb5",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.4.freebsd-386.tar.gz",
       "checksum": "36c5cc2ebef4b4404b12f2b5f2dfd23d73ecdbcc",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.4.freebsd-amd64.tar.gz",
       "checksum": "9441745b9c61002feedee8f0016c082b56319e44",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.4.linux-386.tar.gz",
       "checksum": "cb18d8122bfd3bbba20fa1a19b8f7566dcff795d",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.4.linux-amd64.tar.gz",
       "checksum": "cd82abcb0734f82f7cf2d576c9528cebdafac4c6",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.4.windows-386.zip",
       "checksum": "f44240a1750dd051476ae78e9ad0502bc5c7661d",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.4.windows-amd64.zip",
       "checksum": "44f103d558b293919eb680041625c262dd00eb9a",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -5094,70 +5094,70 @@
   ],
   "1.4.1": [
     {
-      "url": "/dl/go1.4.1.darwin-386-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.4.1.darwin-386-osx10.6.tar.gz",
       "checksum": "c6336247f0f2e734be7d59cb13e9517abe2e75ca",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.4.1.darwin-386-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.4.1.darwin-386-osx10.8.tar.gz",
       "checksum": "7b1b94a120738565a740f56d0bd4771e841ef4e8",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.4.1.darwin-amd64-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.4.1.darwin-amd64-osx10.6.tar.gz",
       "checksum": "aba30d6ef5cacc9cb508cff12cc54bc843b4e5de",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.4.1.darwin-amd64-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.4.1.darwin-amd64-osx10.8.tar.gz",
       "checksum": "95d0ff29347e44c80a4545b84ca4eafcbfddcdb7",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.4.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.4.1.freebsd-386.tar.gz",
       "checksum": "e1e98054a3c741e890d24744653e642410afac8f",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.4.1.freebsd-amd64.tar.gz",
       "checksum": "ff05fa5255473a314b61f9ed6aa61c22e11ba606",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.4.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.4.1.linux-386.tar.gz",
       "checksum": "8d0d0fde13062373c70986ef0afd1c19d90d173a",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.4.1.linux-amd64.tar.gz",
       "checksum": "3e871200e13c0b059b14866d428910de0a4c51ed",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.4.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.4.1.windows-386.zip",
       "checksum": "5f1b6b8b29fddf5265217e0423b896551bbb85ab",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.4.1.windows-amd64.zip",
       "checksum": "a2cb84516e08c6a26323764af443786733e3132c",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -5166,56 +5166,56 @@
   ],
   "1.4.2": [
     {
-      "url": "/dl/go1.4.2.darwin-386-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.4.2.darwin-386-osx10.6.tar.gz",
       "checksum": "fb3e6b30f4e1b1be47bbb98d79dd53da8dec24ec",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.4.2.darwin-386-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.4.2.darwin-386-osx10.8.tar.gz",
       "checksum": "65f5610fdb38febd869aeffbd426c83b650bb408",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "386-osx10"
     },
     {
-      "url": "/dl/go1.4.2.darwin-amd64-osx10.6.tar.gz",
+      "url": "https://golang.org/dl/go1.4.2.darwin-amd64-osx10.6.tar.gz",
       "checksum": "00c3f9a03daff818b2132ac31d57f054925c60e7",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.4.2.darwin-amd64-osx10.8.tar.gz",
+      "url": "https://golang.org/dl/go1.4.2.darwin-amd64-osx10.8.tar.gz",
       "checksum": "58a04b3eb9853c75319d9076df6f3ac8b7430f7f",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64-osx10"
     },
     {
-      "url": "/dl/go1.4.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.4.2.linux-386.tar.gz",
       "checksum": "50557248e89b6e38d395fda93b2f96b2b860a26a",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.4.2.linux-amd64.tar.gz",
       "checksum": "5020af94b52b65cc9b6f11d50a67e4bae07b0aff",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.4.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.4.2.windows-386.zip",
       "checksum": "0e074e66a7816561d7947ff5c3514be96f347dc4",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.4.2.windows-amd64.zip",
       "checksum": "91b229a3ff0a1ce6e791c832b0b4670bfc5457b5",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -5224,42 +5224,42 @@
   ],
   "1.4.3": [
     {
-      "url": "/dl/go1.4.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.4.3.darwin-amd64.tar.gz",
       "checksum": "945666c36b42bf859d98775c4f02f807a5bdb6b0",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.4.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.4.3.freebsd-amd64.tar.gz",
       "checksum": "573217c097f78143ea7c54212445c31944750144",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.4.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.4.3.linux-386.tar.gz",
       "checksum": "405777725abe566989cdb436d2efeb2667be670f",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.4.3.linux-amd64.tar.gz",
       "checksum": "332b64236d30a8805fc8dd8b3a269915b4c507fe",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.4.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.4.3.windows-386.zip",
       "checksum": "77ec9b61c1e1bf475463c62c36c395ba9d69aa9e",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.4.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.4.3.windows-amd64.zip",
       "checksum": "821a6773adadd7409380addc4791771f2b057fa0",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -5268,42 +5268,42 @@
   ],
   "1.5": [
     {
-      "url": "/dl/go1.5.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.darwin-amd64.tar.gz",
       "checksum": "b269242c39739ffcf05b8d969fb9787799f48c48",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.freebsd-amd64.tar.gz",
       "checksum": "ea81cc0c2c499a54cd44e0eea81c98a1673a6dae",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.5.linux-386.tar.gz",
       "checksum": "bbb21e32d2f8fe97696d2bb5b29f7ff5ecd5edda",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.linux-amd64.tar.gz",
       "checksum": "5817fa4b2252afdb02e11e8b9dc1d9173ef3bd5a",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.windows-386.zip",
+      "url": "https://golang.org/dl/go1.5.windows-386.zip",
       "checksum": "f5014cd70be18b79bc401f1e35c8d73062124bf0",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.5.windows-amd64.zip",
       "checksum": "559cddfd341c20531689efad5412dcc304f8d85b",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -5312,42 +5312,42 @@
   ],
   "1.5.1": [
     {
-      "url": "/dl/go1.5.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.1.darwin-amd64.tar.gz",
       "checksum": "02451b1f3b2c715edc5587174e35438982663672",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.1.freebsd-amd64.tar.gz",
       "checksum": "78ac27b7c009142ed0d86b899f1711bb9811b7e1",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.5.1.linux-386.tar.gz",
       "checksum": "6ce7328f84a863f341876658538dfdf10aff86ee",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.1.linux-amd64.tar.gz",
       "checksum": "46eecd290d8803887dec718c691cc243f2175fe0",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.5.1.windows-386.zip",
       "checksum": "bb071ec45ef39cd5ed9449b54c5dd083b8233bfa",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.5.1.windows-amd64.zip",
       "checksum": "7815772347ad3e11a096d927c65bfb15d5b0f490",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -5356,42 +5356,42 @@
   ],
   "1.5.2": [
     {
-      "url": "/dl/go1.5.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.2.darwin-amd64.tar.gz",
       "checksum": "4f30332a56e9c8a36daeeff667bab3608e4dffd2",
       "checksumAlgorithm": "SHA1",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.2.freebsd-amd64.tar.gz",
       "checksum": "34bbe347a95908ca440e4bf584a200522bba1985",
       "checksumAlgorithm": "SHA1",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.5.2.linux-386.tar.gz",
       "checksum": "49ff1c2510eaba80423e55a633901464b28437ef",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.2.linux-amd64.tar.gz",
       "checksum": "cae87ed095e8d94a81871281d35da7829bd1234e",
       "checksumAlgorithm": "SHA1",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.5.2.windows-386.zip",
       "checksum": "a9b265268a4632ad6f7ca8769e6a34eb1522f784",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.5.2.windows-amd64.zip",
       "checksum": "5eb85b0eec36cfef05700935f2420b6104986733",
       "checksumAlgorithm": "SHA1",
       "os": "windows",
@@ -5400,42 +5400,42 @@
   ],
   "1.5.3": [
     {
-      "url": "/dl/go1.5.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.3.darwin-amd64.tar.gz",
       "checksum": "18723e4d486f3b743397273806f360275c2f8305b34a2c913b03c5be07b47654",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.3.freebsd-amd64.tar.gz",
       "checksum": "d2720ca9d69ad3e805b114263f3cf861a62c486c6acd045fb199343c76ce78d2",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.5.3.linux-386.tar.gz",
       "checksum": "c1ce206b7296db1b10ff7896044d9ca50e87efa5bc3477e8fd8c2fb149bfca8f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.3.linux-amd64.tar.gz",
       "checksum": "43afe0c5017e502630b1aea4d44b8a7f059bf60d7f29dfd58db454d4e4e0ae53",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.5.3.windows-386.zip",
       "checksum": "f35cefa3f834611611249bc6607df804b0bb81ce06e444078e1fa00a1d811e06",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.5.3.windows-amd64.zip",
       "checksum": "0a863ba10560c51fa6c4d4ad1180abbc3220b7ecd41159160c322f0b19e06460",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5444,42 +5444,42 @@
   ],
   "1.5.4": [
     {
-      "url": "/dl/go1.5.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.4.darwin-amd64.tar.gz",
       "checksum": "c48f9b0a6dd65708291a5a7a6f733b77604980acf18b8357824aba2b5fd0d250",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.4.freebsd-amd64.tar.gz",
       "checksum": "0e1d2c7d6bc7b7f052006fa0867e825530b3f32950dfe14e63c158cbdbb154c7",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.5.4.linux-386.tar.gz",
       "checksum": "4b2b29d44144d0d306ba34ca5559aa9314c8f31165421ade2b59c74c28059690",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.5.4.linux-amd64.tar.gz",
       "checksum": "a3358721210787dc1e06f5ea1460ae0564f22a0fbd91be9dcd947fb1d19b9560",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.5.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.5.4.windows-386.zip",
       "checksum": "16b28315291b8cbf73614b675a7198015a35bf2ec7d2692d95cbf4ee27c555d9",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.5.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.5.4.windows-amd64.zip",
       "checksum": "1201053d5659a5fc5c82dff58c3eaee66ecd02901621725cfdfff1681278bd1a",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5488,56 +5488,56 @@
   ],
   "1.6": [
     {
-      "url": "/dl/go1.6.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.darwin-amd64.tar.gz",
       "checksum": "8b686ace24c0166738fd9f6003503f9d55ce03b7f24c963b043ba7bb56f43000",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.freebsd-386.tar.gz",
       "checksum": "67f0278e0650b303156adbfe012317b9ce75396e3a28cbc0a8210284bb07ab85",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.freebsd-amd64.tar.gz",
       "checksum": "3763015cdc7971e10f90fb5bec80d885e9956f836277dcb35a2166ffbd7af9b5",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.linux-386.tar.gz",
       "checksum": "7a240a0f45e559d47ea07319d9faf838225eb9e18174f56a76ccaf9860dbb9b1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.linux-amd64.tar.gz",
       "checksum": "5470eac05d273c74ff8bac7bef5bad0b5abbd1c4052efbdbc8db45332e836b0b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.6.linux-armv6l.tar.gz",
       "checksum": "c6c1859acd3727f23f900bde855b5fd0f74d36b1d10f6dd7beddebfb57513d0b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.6.windows-386.zip",
+      "url": "https://golang.org/dl/go1.6.windows-386.zip",
       "checksum": "ac41a46f44d0ea5b83ad7e6a55ee1d58c6a01b7ab7342e243f232510342f16f0",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.6.windows-amd64.zip",
       "checksum": "1be06afa469666d636a00928755c4bcd6403a01f5761946b2b13b8a664f86bac",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5546,56 +5546,56 @@
   ],
   "1.6.1": [
     {
-      "url": "/dl/go1.6.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.1.darwin-amd64.tar.gz",
       "checksum": "3c3801d784043cca19388b3e09fa0e4706a97452c3a506049593bad7fa126978",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.1.freebsd-386.tar.gz",
       "checksum": "8d9ad38e89ca4cee50b639e0a9886b020594f0b093781e938d4a6188505310d4",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.1.freebsd-amd64.tar.gz",
       "checksum": "938f15cc399c7af9dbb88804d3c2c1cc1c8bf78a25c4b70ffc865d1a476cf5c4",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.1.linux-386.tar.gz",
       "checksum": "f1c07a6689405cf91e06f0c25ef99b892f10eb2c49d7fd5b7b015a14576d7760",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.1.linux-amd64.tar.gz",
       "checksum": "6d894da8b4ad3f7f6c295db0d73ccc3646bce630e1c43e662a0120681d47e988",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.6.1.linux-armv6l.tar.gz",
       "checksum": "bb963abf71c0b80bc6b3befa5f3a0f60552bbe3cc19ef5b77ce81f0a2ecc00fe",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.6.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.6.1.windows-386.zip",
       "checksum": "7ecd878015b0bc60254b58e02ee4fea6b8904195edcbc8779d8472a95f48a09d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.6.1.windows-amd64.zip",
       "checksum": "1505afbcc5f71598c6ffd2a56ad550e4e8728c05649e9085f725e38d6b5a0fb8",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5604,56 +5604,56 @@
   ],
   "1.6.2": [
     {
-      "url": "/dl/go1.6.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.2.darwin-amd64.tar.gz",
       "checksum": "6ebbafcac53bbbf8c4105fa84b63cca3d6ce04370f5a04ac2ac065782397fc26",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.2.freebsd-386.tar.gz",
       "checksum": "efa6025948c9c56decee300e5e6eca4de8e38c30e8cde91944dcef2fcfa8d8fe",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.2.freebsd-amd64.tar.gz",
       "checksum": "a0b5c9eef56dc5f32ca26c8e5cefa7bebd6c06540b382a52db055a1d8da7e92a",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.2.linux-386.tar.gz",
       "checksum": "76ae80990f3b46fe1e0457cc0899979e49a2e927eb33af7ddb7611b400b7d6af",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.2.linux-amd64.tar.gz",
       "checksum": "e40c36ae71756198478624ed1bb4ce17597b3c19d243f3f0899bb5740d56212a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.2.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.6.2.linux-armv6l.tar.gz",
       "checksum": "337a08dcf0c4199e1ad84ac0fb1e07422b2603cc1c5f44ebb093a9e864320f3a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.6.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.6.2.windows-386.zip",
       "checksum": "baf8b0412145911fd1034875fe95f1f0b7d4e7f59271c5642f0ad78a017d724e",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.6.2.windows-amd64.zip",
       "checksum": "4367a147b6351c4975732375a21a098c90d26ca0e948245f602295aab389e0d0",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5662,56 +5662,56 @@
   ],
   "1.6.3": [
     {
-      "url": "/dl/go1.6.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.3.darwin-amd64.tar.gz",
       "checksum": "2cd8c824d485a7e73522287278981a528e8f9cb8d3dea41719e29e1bd31ca70a",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.3.freebsd-386.tar.gz",
       "checksum": "b22bd392afe8b6bbfb6af80bb728a03a66304cc025bd9964dbeac426a1f03c75",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.3.freebsd-amd64.tar.gz",
       "checksum": "d1e7c0b0cdb86edcfe20dfbf46f0bcfd34c4b4088972660f2b48d205ac1beb0b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.3.linux-386.tar.gz",
       "checksum": "4d0657f4760c81c1b208939ae58f6fc06f936ee51b8cdcf75e5136d0d0c6df94",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.3.linux-amd64.tar.gz",
       "checksum": "cdde5e08530c0579255d6153b08fdb3b8e47caabbe717bc7bcd7561275a87aeb",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.6.3.linux-armv6l.tar.gz",
       "checksum": "5fc3bd911898e1c9eaf418f56609ce426efd52a4b04b6b59a9af345e8da4a6db",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.6.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.6.3.windows-386.zip",
       "checksum": "3aa8c3208272143c2eadb67976e6e41048a95ff5ac0b55ea4b3b0c88a9ca1a8a",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.6.3.windows-amd64.zip",
       "checksum": "6a18e5ed8b39785338986aecc6a3f36f5c4be286ff52db0ae3bcd2275ab70df0",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5720,63 +5720,63 @@
   ],
   "1.6.4": [
     {
-      "url": "/dl/go1.6.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.4.darwin-amd64.tar.gz",
       "checksum": "8db84ba3237ba57250bc1ce41ecba0fd5c28b0b14d026b9a3c62498404fa4d20",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.4.freebsd-386.tar.gz",
       "checksum": "e1c7e6b8a5c54d4964afbe1879e0ba174c4b592ac8daaa540a6e2a9ac2ed19cc",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.4.freebsd-amd64.tar.gz",
       "checksum": "39a04a209f1bc96f9e6cdc844b70860c3fe0016e95d86f41ca9c51f824c6adb4",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.6.4.linux-386.tar.gz",
       "checksum": "d9a4524dd6192bfa180fe462a468aa92fbeb0cca4887d16a9496064ceef1e94b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.6.4.linux-amd64.tar.gz",
       "checksum": "b58bf5cede40b21812dfa031258db18fc39746cc0972bc26dae0393acc377aaf",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.6.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.6.4.linux-armv6l.tar.gz",
       "checksum": "ff60747ff08c6cb3521b0557b91fbbe7c419937e5f0332acccf308e82f28dbc6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.6.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.6.4.linux-ppc64le.tar.gz",
       "checksum": "57c6e80fb2ea26601f5185e4ae31d12ce79af3f1a4a588047e1f341ad107d2ec",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.6.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.6.4.windows-386.zip",
       "checksum": "91fb3e13dfba94c13334a3ce8362ed6dfd0e5e94c4a1251517223571c2410d73",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.6.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.6.4.windows-amd64.zip",
       "checksum": "4fc871ac03f5ca5978ad2ae860192e6a39dc2b1286afbe86f4947faab84ab231",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5785,56 +5785,56 @@
   ],
   "1.7": [
     {
-      "url": "/dl/go1.7.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.darwin-amd64.tar.gz",
       "checksum": "51d905e0b43b3d0ed41aaf23e19001ab4bc3f96c3ca134b48f7892485fc52961",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.freebsd-386.tar.gz",
       "checksum": "5c24520f5366ca44cf0019dc5b22c8695726f3dc26553d24d56d0c7d4389d00f",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.freebsd-amd64.tar.gz",
       "checksum": "97e1c2f4720d710db948cf94e9c30536f2e653ad49edf684e6f3821296008d55",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.linux-386.tar.gz",
       "checksum": "1207477aa3471222f0555825f9d6ac2a39abc75839f2dfd357f19f5077f710f2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.linux-amd64.tar.gz",
       "checksum": "702ad90f705365227e902b42d91dd1a40e48ca7f67a2f4b2fd052aaa4295cd95",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.7.linux-armv6l.tar.gz",
       "checksum": "4192592728e2f9fac8ae43abedb4b98d811836c3965035e7cb8c603aa5e65be4",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.7.windows-386.zip",
+      "url": "https://golang.org/dl/go1.7.windows-386.zip",
       "checksum": "9a4323fde431f1638ac40a504c1a96f584b6a7a53931599f95df4c8dd530b627",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.7.windows-amd64.zip",
       "checksum": "f51aad06644cc8bd119d2f6933334fa8da24d26e6676fde022cecf5978f1a0c7",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5843,63 +5843,63 @@
   ],
   "1.7.1": [
     {
-      "url": "/dl/go1.7.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.1.darwin-amd64.tar.gz",
       "checksum": "9fd80f19cc0097f35eaa3a52ee28795c5371bb6fac69d2acf70c22c02791f912",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.1.freebsd-386.tar.gz",
       "checksum": "fa1de564c006471b1db7232b5dffb668f5365e8e6e41947d28d7d345af235b60",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.1.freebsd-amd64.tar.gz",
       "checksum": "012c84e7fbb3b8d8feeda2e5f21914d3ca96ca7b22b3f022a1250ebd3c6fc6ae",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.1.linux-386.tar.gz",
       "checksum": "ff6f52de513002b6abb0897654eeb6a7280b420fab3108a382b4f4aba07ad4a6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.1.linux-amd64.tar.gz",
       "checksum": "43ad621c9b014cde8db17393dc108378d37bc853aa351a6c74bf6432c1bbd182",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.7.1.linux-armv6l.tar.gz",
       "checksum": "42d0330734d09cb9f5bae86dad6d0cdf580afcc94242babae0217bdde0d08ec0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.7.1.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.7.1.linux-s390x.tar.gz",
       "checksum": "c479f9cf58b29fb4ec7fd9aa9fa4f8204f51a0dea8eccf48683e9d16dd108ab0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.7.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.7.1.windows-386.zip",
       "checksum": "312fcbb84c0b4268e6e0351dccf0d6e9bb226c9934b5ee81bd7865a693a68aaa",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.7.1.windows-amd64.zip",
       "checksum": "af2b836bb894672cf4c28df32a2ee3ff560e2b463e1ab44bb99833064ba09e5f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5908,63 +5908,63 @@
   ],
   "1.7.3": [
     {
-      "url": "/dl/go1.7.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.3.darwin-amd64.tar.gz",
       "checksum": "2ef310fa48b43dfed7b4ae063b5facba130ed0db95745c538dfc3e30e7c0de04",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.3.freebsd-386.tar.gz",
       "checksum": "e3ac58b1ea8272570adb646bcf4f313d52afe453c83f155ef3f931f472261f0e",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.3.freebsd-amd64.tar.gz",
       "checksum": "78e8987603ab379c9aa1707e027e46978a26f71caf5c0df4cf3a4627570efff5",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.3.linux-386.tar.gz",
       "checksum": "d39d562c3247b11ae659afe1e131a3287c60b7de207ca5f25684c26f1c1dff5c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.3.linux-amd64.tar.gz",
       "checksum": "508028aac0654e993564b6e2014bf2d4a9751e3b286661b0b0040046cf18028e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.7.3.linux-armv6l.tar.gz",
       "checksum": "d02912d121e1455e775a5aa4ecdb2a04f8483ba846e6d2341e1f35b8e507d7b5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.7.3.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.7.3.linux-s390x.tar.gz",
       "checksum": "cadbf9cab94c91b4e8d37884cbe4dd237f983b4c92238c0e93628c166440fb50",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.7.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.7.3.windows-386.zip",
       "checksum": "d0ac2d3aaa20452d0f09112f034cca1c5b8560452a45e10523af7f0a1089c792",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.7.3.windows-amd64.zip",
       "checksum": "9fe41313b97e2a6a703f5ae22938c7d9ac4336a128b522376c224ba97e8c7f01",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -5973,70 +5973,70 @@
   ],
   "1.7.4": [
     {
-      "url": "/dl/go1.7.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.4.darwin-amd64.tar.gz",
       "checksum": "f86c727012e33f3f482b049281aaee24211fe29dfafd121d93f32799a6b6ba2d",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.4.freebsd-386.tar.gz",
       "checksum": "5f70cb139dec6c8b6b1788afd0905eea1b719e05c1d5e815d0d2779e00a28bbf",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.4.freebsd-amd64.tar.gz",
       "checksum": "c560bd755f04528385b35c561bc6b07ec43311cef82143d96cb347ee600ec333",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.4.linux-386.tar.gz",
       "checksum": "31d27752bada47de84e8884cabe6dc13140e459e3aad540c17abc0fcac370c54",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.4.linux-amd64.tar.gz",
       "checksum": "47fda42e46b4c3ec93fa5d4d4cc6a748aa3f9411a2a2b7e08e3a6d80d753ec8b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.7.4.linux-armv6l.tar.gz",
       "checksum": "075c5f4446234e26c1380003ff2b050f0c7e63591410bab65355a945601bf245",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.7.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.7.4.linux-ppc64le.tar.gz",
       "checksum": "fe13807365c2ceb871ba30c10695b1d9cffddba7703cbce07bd9e539bbf2cd56",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.7.4.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.7.4.linux-s390x.tar.gz",
       "checksum": "d9c95281a08282c8f3c6e66648164214c02bc4af0b1aa28a8142ecdb2309d602",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.7.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.7.4.windows-386.zip",
       "checksum": "49df7846ab04d6106cc501526c14c055788e8c67590a967fb4abef7b8b70751f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.7.4.windows-amd64.zip",
       "checksum": "36739164fed38a6da908813aba48d72fb22fea923de5611a85a81135b7cfceb9",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6045,70 +6045,70 @@
   ],
   "1.7.5": [
     {
-      "url": "/dl/go1.7.5.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.5.darwin-amd64.tar.gz",
       "checksum": "2e2a5e0a5c316cf922cf7d59ee5724d49fc35b07a154f6c4196172adfc14b2ca",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.5.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.5.freebsd-386.tar.gz",
       "checksum": "a47c56c7f5bd33e0a0877fbee0daa1eceb6885954796ef63ffa25a570d73aa78",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.5.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.5.freebsd-amd64.tar.gz",
       "checksum": "c52e55a25d7925b5075de2266453d4ddf7b9245e26dbcaccb700129481ac9842",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.5.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.5.linux-386.tar.gz",
       "checksum": "432cb92ae656f6fe1fa96a981782ef5948438b6da6691423aae900918b1eb955",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.5.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.5.linux-amd64.tar.gz",
       "checksum": "2e4dd6c44f0693bef4e7b46cc701513d74c3cc44f2419bf519d7868b12931ac3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.5.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.7.5.linux-armv6l.tar.gz",
       "checksum": "cf93c8171dda189c226fe337e3aae11db24bd600841caab36c91d753f631aa2b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.7.5.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.7.5.linux-ppc64le.tar.gz",
       "checksum": "ced737e36f2b2017b59f31cce86f50a2519245f017a81b8dce93bf986717e3ed",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.7.5.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.7.5.linux-s390x.tar.gz",
       "checksum": "858df47609594570479ff937e3704c58e06b40e485ce29d7f934eae87b7a4450",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.7.5.windows-386.zip",
+      "url": "https://golang.org/dl/go1.7.5.windows-386.zip",
       "checksum": "de367304d1d654ff23d74a2644a457b7740c2da46bc3abedc46f1317f97316ad",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.5.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.7.5.windows-amd64.zip",
       "checksum": "01eb518cb5a12edd6cf7380ec17ebedee755e3ce7e5362febeebb9e70e45fcaa",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6117,70 +6117,70 @@
   ],
   "1.7.6": [
     {
-      "url": "/dl/go1.7.6.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.6.darwin-amd64.tar.gz",
       "checksum": "2eec332ac3162d9e19125645176a9477245b47f4657c2f2715818f2a4739f245",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.6.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.6.freebsd-386.tar.gz",
       "checksum": "43559a1489b5aa670a3b78da54aebc8064d32c3c6eecd2430270e399e2e0a278",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.6.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.6.freebsd-amd64.tar.gz",
       "checksum": "79f6afb90980159bfec10165d8102dbb6cf2a1aee018fb66b2eb799ba5e51205",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.6.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.7.6.linux-386.tar.gz",
       "checksum": "99f79d4e0f966f492794963ecbf4b08c16a9a268f2c09053a5ce10b343ee4082",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.6.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.7.6.linux-amd64.tar.gz",
       "checksum": "ad5808bf42b014c22dd7646458f631385003049ded0bb6af2efc7f1f79fa29ea",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.7.6.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.7.6.linux-armv6l.tar.gz",
       "checksum": "fc5c40fb1f76d0978504b94cd06b5ea6e0e216ba1d494060d081e022540900f8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.7.6.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.7.6.linux-ppc64le.tar.gz",
       "checksum": "8b5b602958396f165a3547a1308ab91ae3f2ad8ecb56063571a37aadc2df2332",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.7.6.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.7.6.linux-s390x.tar.gz",
       "checksum": "d692643d1ac4f4dea8fb6d949ffa750e974e63ff0ee6ca2a7c38fc7c90da8b5b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.7.6.windows-386.zip",
+      "url": "https://golang.org/dl/go1.7.6.windows-386.zip",
       "checksum": "adc772f1d38a38a985d95247df3d068a42db841489f72a228f51080125f78b8f",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.7.6.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.7.6.windows-amd64.zip",
       "checksum": "3c648f9b89b7e0ed746c211dbf959aa230c8034506dd70c9852bf0f94d06065d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6189,70 +6189,70 @@
   ],
   "1.8": [
     {
-      "url": "/dl/go1.8.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.darwin-amd64.tar.gz",
       "checksum": "6fdc9f98b76a28655a8770a1fc8197acd8ef746dd4d8a60589ce19604ba2a120",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.freebsd-386.tar.gz",
       "checksum": "9965b73686fcf82a7d002e75b30d4125cc9f47906c1e2b2f0ef036a6665f0348",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.freebsd-amd64.tar.gz",
       "checksum": "e750579f390fe5c95de30c2a52d7ce88250cf971c435323373d22bfab8a63431",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.linux-386.tar.gz",
       "checksum": "8f618dc8b01c2e53e639a38d780645b8424e671e292c7b518248022205d6a448",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.linux-amd64.tar.gz",
       "checksum": "53ab94104ee3923e228a2cb2116e5e462ad3ebaeea06ff04463479d7f12d27ca",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.8.linux-armv6l.tar.gz",
       "checksum": "32553dbb342f74a821ed5069cb72ec7e135c031102e7d01c6bc4da8ad6df5202",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.8.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.8.linux-ppc64le.tar.gz",
       "checksum": "7e78afe33377b4d4c04817d48feb9f2a904406d32216df015d44462f0432643b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.8.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.8.linux-s390x.tar.gz",
       "checksum": "fb893a546902c2afdff929ddf5a9fbc0fd50b9017126ee85e80604d8620010fe",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.8.windows-386.zip",
+      "url": "https://golang.org/dl/go1.8.windows-386.zip",
       "checksum": "b8199a4af9327807803d2892268dfbffb615f98d717cd824833a97e77f981f46",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.8.windows-amd64.zip",
       "checksum": "cb27fe210f3a9d10329d48514895d2a1e3651125a7c3c758f0358a5bfc0e3060",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6261,70 +6261,70 @@
   ],
   "1.8.1": [
     {
-      "url": "/dl/go1.8.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.1.darwin-amd64.tar.gz",
       "checksum": "25b026fe2f4de7c80b227f69588b06b93787f5b5f134fbf2d652926c08c04bcd",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.1.freebsd-386.tar.gz",
       "checksum": "8f6dd6acd2076e21b4e154d3daa8243fcedbdfd63be7cb54a3dae8be66e46bd9",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.1.freebsd-amd64.tar.gz",
       "checksum": "91065d4bb311bba74d7c1e3e6bab82fbba24c9da8aeca9e803caabcc66de1af7",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.1.linux-386.tar.gz",
       "checksum": "cb3f4527112075a8b045d708f793aeee2709d2f5ddd320973a1413db06fddb50",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.1.linux-amd64.tar.gz",
       "checksum": "a579ab19d5237e263254f1eac5352efcf1d70b9dacadb6d6bb12b0911ede8994",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.8.1.linux-armv6l.tar.gz",
       "checksum": "e8a8326913640409028ef95c2107773f989b1b2a6e11ceb463c77c42887381da",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.8.1.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.8.1.linux-ppc64le.tar.gz",
       "checksum": "b7b47572a2676449716865a66901090c057f6f1d8dfb1e19528fcd0372e5ce74",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.8.1.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.8.1.linux-s390x.tar.gz",
       "checksum": "0a59f4034a27fc51431989da520fd244d5261f364888134cab737e5bc2158cb2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.8.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.8.1.windows-386.zip",
       "checksum": "9738365e64d4d80ea54487915c9bfc0c3bbaa7d68ec78487988f80ebe8129c57",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.8.1.windows-amd64.zip",
       "checksum": "bb6f0fbef8b80c382455af8699bfbb7fe89256d4baf06d927feaeceb7342e4ee",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6333,70 +6333,70 @@
   ],
   "1.8.2": [
     {
-      "url": "/dl/go1.8.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.2.darwin-amd64.tar.gz",
       "checksum": "3f783c33686e6d74f6c811725eb3775c6cf80b9761fa6d4cebc06d6d291be137",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.2.freebsd-386.tar.gz",
       "checksum": "cea0948d7b5e721d2be871c903b4a57488b8a0253979d32609de010f32f9624b",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.2.freebsd-amd64.tar.gz",
       "checksum": "8accaa61671d4ac2c75106963960a3720a2bd8757e1ac1738f2e58a4b0644b58",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.2.linux-386.tar.gz",
       "checksum": "00bc94606610bf25c660d6106fa8e61cca6a276c046f3ceb9091053e99ceebe9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.2.linux-amd64.tar.gz",
       "checksum": "5477d6c9a4f96fa120847fafa88319d7b56b5d5068e41c3587eebe248b939be7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.2.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.8.2.linux-armv6l.tar.gz",
       "checksum": "a1942b2833e7d2685d7dbb7ac81c66125c351f24c7f006e8ae4a4283905257d1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.8.2.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.8.2.linux-ppc64le.tar.gz",
       "checksum": "031035eab11903237e02007fc69c085bd4769ff2e2aa5e9af427ddaed3d37e2b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.8.2.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.8.2.linux-s390x.tar.gz",
       "checksum": "f091afb86501191270e14a653a056e8e7635e18a72e43cfbd13093b2482ca7a8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.8.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.8.2.windows-386.zip",
       "checksum": "75e295f5cd0eb3236e68324ac51b9e54a1aad1fa3a3b259f62cc11e05d948aed",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.8.2.windows-amd64.zip",
       "checksum": "9bfa4d497caee1b7ec8720acdea2fa8af8d51b525ddc7e4648a63a3138a6a8e3",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6405,70 +6405,70 @@
   ],
   "1.8.3": [
     {
-      "url": "/dl/go1.8.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.3.darwin-amd64.tar.gz",
       "checksum": "f20b92bc7d4ab22aa18270087c478a74463bd64a893a94264434a38a4b167c05",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.3.freebsd-386.tar.gz",
       "checksum": "d301cc7c2b8b0ccb384ac564531beee8220727fd27ca190b92031a2e3e230224",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.3.freebsd-amd64.tar.gz",
       "checksum": "1bf5f076d48609012fe01b95e2a58e71e56719a04d576fe3484a216ad4b9c495",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.3.linux-386.tar.gz",
       "checksum": "ff4895eb68fb1daaec41c540602e8bb4c1e8bb2f0e7017367171913fc9995ed2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.3.linux-amd64.tar.gz",
       "checksum": "1862f4c3d3907e59b04a757cfda0ea7aa9ef39274af99a784f5be843c80c6772",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.8.3.linux-armv6l.tar.gz",
       "checksum": "3c30a3e24736ca776fc6314e5092fb8584bd3a4a2c2fa7307ae779ba2735e668",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.8.3.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.8.3.linux-ppc64le.tar.gz",
       "checksum": "e5fb00adfc7291e657f1f3d31c09e74890b5328e6f991a3f395ca72a8c4dc0b3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.8.3.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.8.3.linux-s390x.tar.gz",
       "checksum": "e2ec3e7c293701b57ca1f32b37977ac9968f57b3df034f2cc2d531e80671e6c8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.8.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.8.3.windows-386.zip",
       "checksum": "9e2bfcb8110a3c56f23b91f859963269bc29fd114190fecfd0a539395272a1c7",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.8.3.windows-amd64.zip",
       "checksum": "de026caef4c5b4a74f359737dcb2d14c67ca45c45093755d3b0d2e0ee3aafd96",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6477,70 +6477,70 @@
   ],
   "1.8.4": [
     {
-      "url": "/dl/go1.8.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.4.darwin-amd64.tar.gz",
       "checksum": "cf803053aec24425d7be986af6dff0051bb48527bcdfa5b9ffeb4d40701ab54e",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.4.freebsd-386.tar.gz",
       "checksum": "4764920bc94cc9723e7a9a65ae7764922e0ab6148e1cf206bbf37062997fdf4c",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.4.freebsd-amd64.tar.gz",
       "checksum": "21dd9899b91f4aaeeb85c7bb7db6cd4b44be089b2a7397ea8f9f2e3397a0b5c6",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.4.linux-386.tar.gz",
       "checksum": "00354388d5f7d21b69c62361e73250d2633124e8599386f704f6dd676a2f82ac",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.4.linux-amd64.tar.gz",
       "checksum": "0ef737a0aff9742af0f63ac13c97ce36f0bbc8b67385169e41e395f34170944f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.8.4.linux-armv6l.tar.gz",
       "checksum": "76329898bb9f2be0f86b07f05a6336818cb12f3a416ab3061aa0d5f2ea5c6ff0",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.8.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.8.4.linux-ppc64le.tar.gz",
       "checksum": "0f043568d65fd8121af6b35a39f4f20d292a03372b6531e80b743ee0689eb717",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.8.4.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.8.4.linux-s390x.tar.gz",
       "checksum": "aa998b7ac8882c549f7017d2e9722a3102cb9e6b92010baf5153a6dcf98205b1",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.8.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.8.4.windows-386.zip",
       "checksum": "c0f949174332e5b9d4f025c84338bbec1c94b436f249c20aade04a024537f0be",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.8.4.windows-amd64.zip",
       "checksum": "2ddfea037fd5e2eeb0cb854c095f6e44aaec27e8bbf76dca9a11a88e3a49bbf7",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6549,77 +6549,77 @@
   ],
   "1.8.5": [
     {
-      "url": "/dl/go1.8.5.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.darwin-amd64.tar.gz",
       "checksum": "af5bd0c8e669a61f4b38fcce03bbf02f1ce672724a95c2ad61e89c6785f5c51e",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.5.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.freebsd-386.tar.gz",
       "checksum": "b7e246c9ec1b68e481abe6190caf79cc7179b9308c30076081a9dc90b3a12f99",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.5.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.freebsd-amd64.tar.gz",
       "checksum": "8a025284c1911aba8d133e9fcadd6a6dcf5dc78b0d8139be88747cea09773407",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.5.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.linux-386.tar.gz",
       "checksum": "cf959b60b89acb588843ff985ecb47a7f6c37da6e4987739ab4aafad7211464f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.5.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.linux-amd64.tar.gz",
       "checksum": "4f8aeea2033a2d731f2f75c4d0a4995b357b22af56ed69b3015f4291fca4d42d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.5.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.linux-arm64.tar.gz",
       "checksum": "6c552ae1e77c52944e0f9b9034761bd3dcc3fef57dad6d751a53638783b07d2c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.8.5.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.linux-armv6l.tar.gz",
       "checksum": "f5c58e7fd6cdfcc40b94c6655cf159b25836dffe13431f683b51705b8a67d608",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.8.5.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.linux-ppc64le.tar.gz",
       "checksum": "1ee0874ce8c8625e14b4457a4861777be78f30067d914bcb264f7e0331d087de",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.8.5.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.8.5.linux-s390x.tar.gz",
       "checksum": "e978a56842297dc8924555540314ff09128e9a62da9881c3a26771ddd5d7ebc2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.8.5.windows-386.zip",
+      "url": "https://golang.org/dl/go1.8.5.windows-386.zip",
       "checksum": "c14d800bb79bf38a945f83cf37005609b719466c0051d20a5fc59d6efdd6fc66",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.5.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.8.5.windows-amd64.zip",
       "checksum": "137827cabff27cc36cbe13018f629a6418c2a6af85adde1b1bfb8d000c9fc1ae",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6628,77 +6628,77 @@
   ],
   "1.8.6": [
     {
-      "url": "/dl/go1.8.6.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.darwin-amd64.tar.gz",
       "checksum": "12594e364969f9a0d45071df388930b826b1687520e57994b4df3cfbaa163147",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.6.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.freebsd-386.tar.gz",
       "checksum": "c0a25d81aa8f8fae24110910749e19399506be093939828e70cb5296d91d6684",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.6.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.freebsd-amd64.tar.gz",
       "checksum": "d4c104ff0f6ba44287370cc63953984341662a3de4616e584785e33347e80a7c",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.6.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.linux-386.tar.gz",
       "checksum": "04e8a97ef3431e3157fe2629f9b162f8f845ea52bddf8b56bad2c9e21041b3b6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.6.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.linux-amd64.tar.gz",
       "checksum": "f558c91c2f6aac7222e0bd83e6dd595b8fac85aaa96e55d15229542eb4aaa1ff",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.6.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.linux-arm64.tar.gz",
       "checksum": "7ed8fd5b4109394e23a6a120686b8ee91806d6f9b16222ca9dbc8778e7a2fbc4",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.8.6.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.linux-armv6l.tar.gz",
       "checksum": "590cd6a06bb7482b0fb98d8a4f3a149975a9bfa6a32f20e85a4c0c68f3dc120d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.8.6.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.linux-ppc64le.tar.gz",
       "checksum": "9a02793709d68085929c492f3f9cad140845185eaef8510f66c8a79fed2170e2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.8.6.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.8.6.linux-s390x.tar.gz",
       "checksum": "571c438b3b9df2b3b9987712a3ce8c0ace6c0d45c3ac3d9224d864e2aa8cbd89",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.8.6.windows-386.zip",
+      "url": "https://golang.org/dl/go1.8.6.windows-386.zip",
       "checksum": "21d5207362af2796d0f166af086a0cbdf3e4dc7c150300af168dd13f748da4fe",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.6.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.8.6.windows-amd64.zip",
       "checksum": "7b6dce9e0119ab3db33ebedaa502a3c6624f2f61edec2d292d4aef0827c286d3",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6707,77 +6707,77 @@
   ],
   "1.8.7": [
     {
-      "url": "/dl/go1.8.7.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.darwin-amd64.tar.gz",
       "checksum": "02bc6fb577538d0279e3e760c19ac3985e1a44ee87b8920b4c8bf986b4a5a5a7",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.7.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.freebsd-386.tar.gz",
       "checksum": "f0f7176bcca829e10abc97ec2f543ad00924d15e5f8fefdfbe833fd8674b0954",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.7.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.freebsd-amd64.tar.gz",
       "checksum": "602f3125335a4469e32b3eb316d854f8720a6719490d7728f4ca7c37d7f0d288",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.7.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.linux-386.tar.gz",
       "checksum": "3afab0048a44f66c4132f1fe26d3301fa4c51b47e7176c2d3f311c49d9aa74d6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.7.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.linux-amd64.tar.gz",
       "checksum": "de32e8db3dc030e1448a6ca52d87a1e04ad31c6b212007616cfcc87beb0e4d60",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.8.7.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.linux-arm64.tar.gz",
       "checksum": "804c2e73eca5ce309f2947aaf437fce9f67463b4fb9484f47c95b632d4eeabf6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.8.7.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.linux-armv6l.tar.gz",
       "checksum": "7aa455a8ddec569e778b23166102bb26f1bdb3ad5feec15b688654a10a9d3d2a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.8.7.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.linux-ppc64le.tar.gz",
       "checksum": "588527ed410653318188b45eb27de098bdb12f95060a648e14587b28bf1761d9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.8.7.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.8.7.linux-s390x.tar.gz",
       "checksum": "a4dc8ceec71e6f22c10e5781a89dec91e9a1819f56822ac38a54de1700df1226",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.8.7.windows-386.zip",
+      "url": "https://golang.org/dl/go1.8.7.windows-386.zip",
       "checksum": "46995f7b022f6638183f1e777be6c9fdaa0cc8156af879db329d5820a2de1f9d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.8.7.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.8.7.windows-amd64.zip",
       "checksum": "633a28e72b95e8372e5416dd4723881d7a7109be08daf097ebce2679939f6a82",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6786,77 +6786,77 @@
   ],
   "1.9": [
     {
-      "url": "/dl/go1.9.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.darwin-amd64.tar.gz",
       "checksum": "c2df361ec6c26fcf20d5569496182cb20728caa4d351bc430b2f0f1212cca3e0",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.freebsd-386.tar.gz",
       "checksum": "9e415e340eaea526170b0fd59aa55939ff4f76c126193002971e8c6799e2ed3a",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.freebsd-amd64.tar.gz",
       "checksum": "ba54efb2223fb4145604dcaf8605d519467f418ab02c081d3cd0632b6b43b6e7",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.linux-386.tar.gz",
       "checksum": "7cccff99dacf59162cd67f5b11070d667691397fd421b0a9ad287da019debc4f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.linux-amd64.tar.gz",
       "checksum": "d70eadefce8e160638a9a6db97f7192d8463069ab33138893ad3bf31b0650a79",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.linux-arm64.tar.gz",
       "checksum": "0958dcf454f7f26d7acc1a4ddc34220d499df845bc2051c14ff8efdf1e3c29a6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.9.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.9.linux-armv6l.tar.gz",
       "checksum": "f52ca5933f7a8de2daf7a3172b0406353622c6a39e67dd08bbbeb84c6496f487",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.9.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.9.linux-ppc64le.tar.gz",
       "checksum": "10b66dae326b32a56d4c295747df564616ec46ed0079553e88e39d4f1b2ae985",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.9.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.9.linux-s390x.tar.gz",
       "checksum": "e06231e4918528e2eba1d3cff9bc4310b777971e5d8985f9772c6018694a3af8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.9.windows-386.zip",
+      "url": "https://golang.org/dl/go1.9.windows-386.zip",
       "checksum": "ecfe6f5be56acedc56cd9ff735f239a12a7c94f40b0ea9753bbfd17396f5e4b9",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.9.windows-amd64.zip",
       "checksum": "874b144b994643cff1d3f5875369d65c01c216bb23b8edddf608facc43966c8b",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6865,77 +6865,77 @@
   ],
   "1.9.1": [
     {
-      "url": "/dl/go1.9.1.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.darwin-amd64.tar.gz",
       "checksum": "59bc6deee2969dddc4490b684b15f63058177f5c7e27134c060288b7d76faab0",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.1.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.freebsd-386.tar.gz",
       "checksum": "0da7ad96606a8ceea85652eb20816077769d51de9219d85b9b224a3390070c50",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.1.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.freebsd-amd64.tar.gz",
       "checksum": "c4eeacbb94821c5f252897a4d49c78293eaa97b29652d789dce9e79bc6aa6163",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.1.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.linux-386.tar.gz",
       "checksum": "2cea1ce9325cb40839601b566bc02b11c92b2942c21110b1b254c7e72e5581e7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.1.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.linux-amd64.tar.gz",
       "checksum": "07d81c6b6b4c2dcf1b5ef7c27aaebd3691cdb40548500941f92b221147c5d9c7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.1.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.linux-arm64.tar.gz",
       "checksum": "d31ecae36efea5197af271ccce86ccc2baf10d2e04f20d0fb75556ecf0614dad",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.9.1.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.linux-armv6l.tar.gz",
       "checksum": "65a0495a50c7c240a6487b1170939586332f6c8f3526abdbb9140935b3cff14c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.9.1.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.linux-ppc64le.tar.gz",
       "checksum": "de57b6439ce9d4dd8b528599317a35fa1e09d6aa93b0a80e3945018658d963b8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.9.1.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.9.1.linux-s390x.tar.gz",
       "checksum": "9adf03574549db82a72e0d721ef2178ec5e51d1ce4f309b271a2bca4dcf206f6",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.9.1.windows-386.zip",
+      "url": "https://golang.org/dl/go1.9.1.windows-386.zip",
       "checksum": "ea9c79c9e6214c9a78a107ef5a7bff775a281bffe8c2d50afa66d2d33998078a",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.1.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.9.1.windows-amd64.zip",
       "checksum": "8dc72a3881388e4e560c2e45f6be59860b623ad418e7da94e80fee012221cc81",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -6944,77 +6944,77 @@
   ],
   "1.9.2": [
     {
-      "url": "/dl/go1.9.2.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.darwin-amd64.tar.gz",
       "checksum": "73fd5840d55f5566d8db6c0ffdd187577e8ebe650c783f68bd27cbf95bde6743",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.2.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.freebsd-386.tar.gz",
       "checksum": "809dcb0a8457c8d0abf954f20311a1ee353486d0ae3f921e9478189721d37677",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.2.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.freebsd-amd64.tar.gz",
       "checksum": "8be985c3e251c8e007fa6ecd0189bc53e65cc519f4464ddf19fa11f7ed251134",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.2.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.linux-386.tar.gz",
       "checksum": "574b2c4b1a248e58ef7d1f825beda15429610a2316d9cbd3096d8d3fa8c0bc1a",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.2.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.linux-amd64.tar.gz",
       "checksum": "de874549d9a8d8d8062be05808509c09a88a248e77ec14eb77453530829ac02b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.2.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.linux-arm64.tar.gz",
       "checksum": "0016ac65ad8340c84f51bc11dbb24ee8265b0a4597dbfdf8d91776fc187456fa",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.9.2.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.linux-armv6l.tar.gz",
       "checksum": "8a6758c8d390e28ef2bcea511f62dcb43056f38c1addc06a8bc996741987e7bb",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.9.2.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.linux-ppc64le.tar.gz",
       "checksum": "adb440b2b6ae9e448c253a20836d8e8aa4236f731d87717d9c7b241998dc7f9d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.9.2.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.9.2.linux-s390x.tar.gz",
       "checksum": "a7137b4fbdec126823a12a4b696eeee2f04ec616e9fb8a54654c51d5884c1345",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.9.2.windows-386.zip",
+      "url": "https://golang.org/dl/go1.9.2.windows-386.zip",
       "checksum": "35d3be5d7b97c6d11ffb76c1b19e20a824e427805ee918e82c08a2e5793eda20",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.2.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.9.2.windows-amd64.zip",
       "checksum": "682ec3626a9c45b657c2456e35cadad119057408d37f334c6c24d88389c2164c",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -7023,77 +7023,77 @@
   ],
   "1.9.3": [
     {
-      "url": "/dl/go1.9.3.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.darwin-amd64.tar.gz",
       "checksum": "f84b39c2ed7df0c2f1648e2b90b2198a6783db56b53700dabfa58afd6335d324",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.3.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.freebsd-386.tar.gz",
       "checksum": "a755739e3be0415344d62ea3b168bdcc9a54f7862ac15832684ff2d3e8127a03",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.3.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.freebsd-amd64.tar.gz",
       "checksum": "f95066089a88749c45fae798422d04e254fe3b622ff030d12bdf333402b186ec",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.3.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.linux-386.tar.gz",
       "checksum": "bc0782ac8116b2244dfe2a04972bbbcd7f1c2da455a768ab47b32864bcd0d49d",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.3.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.linux-amd64.tar.gz",
       "checksum": "a4da5f4c07dfda8194c4621611aeb7ceaab98af0b38bfb29e1be2ebb04c3556c",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.3.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.linux-arm64.tar.gz",
       "checksum": "065d79964023ccb996e9dbfbf94fc6969d2483fbdeeae6d813f514c5afcd98d9",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.9.3.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.linux-armv6l.tar.gz",
       "checksum": "926d6cd6c21ef3419dca2e5da8d4b74b99592ab1feb5a62a4da244e6333189d2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.9.3.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.linux-ppc64le.tar.gz",
       "checksum": "c802194b1af0cd904689923d6d32f3ed68f9d5f81a3e4a82406d9ce9be163681",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.9.3.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.9.3.linux-s390x.tar.gz",
       "checksum": "85e9a257664f84154e583e0877240822bb2fe4308209f5ff57d80d16e2fb95c5",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.9.3.windows-386.zip",
+      "url": "https://golang.org/dl/go1.9.3.windows-386.zip",
       "checksum": "cab7d4e008adefed322d36dee87a4c1775ab60b25ce587a2b55d90c75d0bafbc",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.3.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.9.3.windows-amd64.zip",
       "checksum": "4eee59bb5b70abc357aebd0c54f75e46322eb8b58bbdabc026fdd35834d65e1e",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -7102,77 +7102,77 @@
   ],
   "1.9.4": [
     {
-      "url": "/dl/go1.9.4.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.darwin-amd64.tar.gz",
       "checksum": "0e694bfa289453ecb056cc70456e42fa331408cfa6cc985a14edb01d8b4fec51",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.4.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.freebsd-386.tar.gz",
       "checksum": "ca5874943d1fe5f9698594f65bb4d82f9e0f7ca3a09b1c306819df6f7349fd17",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.4.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.freebsd-amd64.tar.gz",
       "checksum": "d91c3dc997358af47fc0070c09586b3e7aa47282a75169fa6b00d9ac3ca61d89",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.4.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.linux-386.tar.gz",
       "checksum": "d440aee90dad851630559bcee2b767b543ce7e54f45162908f3e12c3489888ab",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.4.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.linux-amd64.tar.gz",
       "checksum": "15b0937615809f87321a457bb1265f946f9f6e736c563d6c5e0bd2c22e44f779",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.4.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.linux-arm64.tar.gz",
       "checksum": "41a71231e99ccc9989867dce2fcb697921a68ede0bd06fc288ab6c2f56be8864",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.9.4.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.linux-armv6l.tar.gz",
       "checksum": "3c8cf3f79754a9fd6b33e2d8f930ee37d488328d460065992c72bc41c7b41a49",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.9.4.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.linux-ppc64le.tar.gz",
       "checksum": "8b25484a7b4b6db81b3556319acf9993cc5c82048c7f381507018cb7c35e746b",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.9.4.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.9.4.linux-s390x.tar.gz",
       "checksum": "129f23b13483b1a7ccef49bc4319daf25e1b306f805780fdb5526142985edb68",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.9.4.windows-386.zip",
+      "url": "https://golang.org/dl/go1.9.4.windows-386.zip",
       "checksum": "ad5905b211e543a1e59758acd4c6f30d446e5af8c4ea997961caf1ef02cdd56d",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.4.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.9.4.windows-amd64.zip",
       "checksum": "880e011ac6f4a509308a62ec6d963dd9d561d0cdc705e93d81c750d7f1c696f4",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -7181,77 +7181,77 @@
   ],
   "1.9.5": [
     {
-      "url": "/dl/go1.9.5.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.darwin-amd64.tar.gz",
       "checksum": "2300c620a307bdee08670a9190e0916337514fd0bec3ea19115329d18c49b586",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.5.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.freebsd-386.tar.gz",
       "checksum": "9f8f7ad7249b26dc7bc8fdd335d89c1cae3de3232ac6c5053171eba9b5923a0a",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.5.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.freebsd-amd64.tar.gz",
       "checksum": "141728cdde1adcb097f252d51aebbcff5e45e30f56bf066fcb158474c293c388",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.5.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.linux-386.tar.gz",
       "checksum": "52e0e3421ac4d9b8d8c89121ea93e5e3180a26679a8ea64ecbeb3657251634a3",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.5.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.linux-amd64.tar.gz",
       "checksum": "d21bdabf4272c2248c41b45cec606844bdc5c7c04240899bde36c01a28c51ee7",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.5.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.linux-arm64.tar.gz",
       "checksum": "d0bb265559cd8613882e6bbd197a80ed7090684117c6fc6900aa58dea2463715",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.9.5.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.linux-armv6l.tar.gz",
       "checksum": "e9b6f0cbd95ff3077ddeaec1958be77d9675f0cf5652a67152d28d84707a4e9e",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.9.5.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.linux-ppc64le.tar.gz",
       "checksum": "dfd928ab818f72b801273c669d86e6c05626f2c2addc1c7178bb715fc608daf2",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.9.5.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.9.5.linux-s390x.tar.gz",
       "checksum": "82c86885c8cc4d62ff81f828529c72cacd0ca8b02d442dc659858c6738363775",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.9.5.windows-386.zip",
+      "url": "https://golang.org/dl/go1.9.5.windows-386.zip",
       "checksum": "c29ea03496a5d61ddcc811110b3d6b8f774e89b19a6dc3839f2d2f82e3789635",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.5.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.9.5.windows-amd64.zip",
       "checksum": "6c3ef0e069c0edb0b5e8575f0efca806f69354a7b808f9846b89046f46a260c2",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -7260,77 +7260,77 @@
   ],
   "1.9.6": [
     {
-      "url": "/dl/go1.9.6.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.darwin-amd64.tar.gz",
       "checksum": "3de992c35021963af33029b7c0703bf25d1a3bb9236d117ebde09a9e12dfe715",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.6.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.freebsd-386.tar.gz",
       "checksum": "e038805a0211dff4935b9ec325a888aa70ab6dc655a2252ae93d8fbd6eb23413",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.6.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.freebsd-amd64.tar.gz",
       "checksum": "d557b31eec03addeede54d007240a3d66d1f439fbf3f0666203fc3ef2e2cfe59",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.6.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.linux-386.tar.gz",
       "checksum": "de65e35d7e540578e78a3c6917b9e9033b55617ef894a1de1a6a6da5a1b948dd",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.6.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.linux-amd64.tar.gz",
       "checksum": "d1eb07f99ac06906225ac2b296503f06cc257b472e7d7817b8f822fe3766ebfe",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.6.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.linux-arm64.tar.gz",
       "checksum": "8596d64b9f582d6209c04513824e428d1c356276180d2089d4dfcf4c7cf8a6cc",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.9.6.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.linux-armv6l.tar.gz",
       "checksum": "73e56ec4408650d9fda0be8282a9ad49c51ad17929b4d20c04cea07249726bd8",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.9.6.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.linux-ppc64le.tar.gz",
       "checksum": "b1203546c68e3be7b5e36a5cfb6ff5ef94bd476f5423035bc7e65255858741ff",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.9.6.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.9.6.linux-s390x.tar.gz",
       "checksum": "2baa6e48eedb8ec7e2a4d2454cdf05d1f46d5a07ff2f03cab5b7b8eadef7e112",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.9.6.windows-386.zip",
+      "url": "https://golang.org/dl/go1.9.6.windows-386.zip",
       "checksum": "1ec01c451f13127bb592b74b8d3e5a9fa1a24e48e9172cda783f0cdda6434904",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.6.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.9.6.windows-amd64.zip",
       "checksum": "0b3a31eb7a46ef3976098cb92fde63c0871dceced91b0a3187953456f8eb8d6e",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
@@ -7339,77 +7339,77 @@
   ],
   "1.9.7": [
     {
-      "url": "/dl/go1.9.7.darwin-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.darwin-amd64.tar.gz",
       "checksum": "3f4f84406dcada4eec785dbc967747f61c1f1b4e36d7545161e282259e9b215f",
       "checksumAlgorithm": "SHA256",
       "os": "darwin",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.7.freebsd-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.freebsd-386.tar.gz",
       "checksum": "9e7e42975747c80aa5efe10d9cbe258669b9f5ea7e647919ba786a0f75627bbe",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.7.freebsd-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.freebsd-amd64.tar.gz",
       "checksum": "19b2bd6b83d806602216e2cacc27e40e97b6026bde0ec18cfb990bd9f2932708",
       "checksumAlgorithm": "SHA256",
       "os": "freebsd",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.7.linux-386.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.linux-386.tar.gz",
       "checksum": "c689fdb0b4f4530e48b44a3e591e53660fcbc97c3757ff9c3028adadabcf8378",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.7.linux-amd64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.linux-amd64.tar.gz",
       "checksum": "88573008f4f6233b81f81d8ccf92234b4f67238df0f0ab173d75a302a1f3d6ee",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "amd64"
     },
     {
-      "url": "/dl/go1.9.7.linux-arm64.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.linux-arm64.tar.gz",
       "checksum": "68f48c29f93e4c69bbbdb335f473d666b9f8791643f4003ef45283a968b41f86",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "arm64"
     },
     {
-      "url": "/dl/go1.9.7.linux-armv6l.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.linux-armv6l.tar.gz",
       "checksum": "83b165d617807d636d2cfe07f34920ab6e5374a07ab02d60edcaec008de608ee",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "armv6l"
     },
     {
-      "url": "/dl/go1.9.7.linux-ppc64le.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.linux-ppc64le.tar.gz",
       "checksum": "66cc2b9d591c8ef5adc4c4454f871546b0bab6be1dcbd151c2881729884fbbdd",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "ppc64le"
     },
     {
-      "url": "/dl/go1.9.7.linux-s390x.tar.gz",
+      "url": "https://golang.org/dl/go1.9.7.linux-s390x.tar.gz",
       "checksum": "7148ba7bc6f40b342d35a28b0cc43dd8f2b2acd7fb3e8891bc95b0f783bc8c9f",
       "checksumAlgorithm": "SHA256",
       "os": "linux",
       "arch": "s390x"
     },
     {
-      "url": "/dl/go1.9.7.windows-386.zip",
+      "url": "https://golang.org/dl/go1.9.7.windows-386.zip",
       "checksum": "0748a66f221f7608d2a6e52dda93bccb5a2d4dd5d8458de481b7f88972558c3c",
       "checksumAlgorithm": "SHA256",
       "os": "windows",
       "arch": "386"
     },
     {
-      "url": "/dl/go1.9.7.windows-amd64.zip",
+      "url": "https://golang.org/dl/go1.9.7.windows-amd64.zip",
       "checksum": "8db4b21916a3bc79f48d0611202ee5814c82f671b36d5d2efcb446879456cd28",
       "checksumAlgorithm": "SHA256",
       "os": "windows",


### PR DESCRIPTION
Due to a change in golang downloads page, the links extracted from the website are now relative to the host.
Handling multiple cases in order to generate absolute links for downloads in remote file.

Also, updating remote file with fixes.